### PR TITLE
Test for the Mass. error page

### DIFF
--- a/site-scrapers/MAImmunizations.js
+++ b/site-scrapers/MAImmunizations.js
@@ -12,6 +12,15 @@ async function ScrapeWebsiteData(browser) {
 	await page.setDefaultNavigationTimeout(3*60*1000);
 	await page.goto(sites.MAImmunizations.website);
 	const pages = await page.$$("nav.pagination span.page:not(.prev):not(.next)");
+	if ((await page.title())==="Application Error") {
+		console.log("Got the Mass. Heroku error page, giving up.");
+		return false;
+	}
+	if (pages.length < 1) {
+		console.log("No content matching our CSS selector (looking for nav.pagination)!");
+		console.log("Here's the page:");
+		console.log(await page.content());
+	}
 	const maxPage = await pages[pages.length - 1].evaluate(
 		(node) => node.innerText
 	);

--- a/site-scrapers/MAImmunizations.js
+++ b/site-scrapers/MAImmunizations.js
@@ -20,6 +20,7 @@ async function ScrapeWebsiteData(browser) {
 		console.log("No content matching our CSS selector (looking for nav.pagination)!");
 		console.log("Here's the page:");
 		console.log(await page.content());
+		return false;
 	}
 	const maxPage = await pages[pages.length - 1].evaluate(
 		(node) => node.innerText


### PR DESCRIPTION
As of 11am, it returns a Heroku error page about half the time.
Catch that and fail fast.

Also, check for other CSS selector serach failures, although it's not
clear under what circumstances that might happen.

Previously we got:

```
  TypeError: Cannot read property 'evaluate' of undefined
      at ScrapeWebsiteData (/Users/jhawk/src/covid-vaccine-scrapers/site-scrapers/MAImmunizations.js:20:48)
      at processTicksAndRejections (internal/process/task_queues.js:93:5)
      at async GetAvailableAppointments (/Users/jhawk/src/covid-vaccine-scrapers/site-scrapers/MAImmunizations.js:5:18)
      at async Promise.all (index 0)
      at async gatherData (/Users/jhawk/src/covid-vaccine-scrapers/main.js:41:19)
      at async execute (/Users/jhawk/src/covid-vaccine-scrapers/main.js:116:2)
      at async /Users/jhawk/src/covid-vaccine-scrapers/main.js:124:3
  The following data would be published:
```

attempting to iterate over the page navigation.

THe Heroku error page looks like this:

```html
<!DOCTYPE html><html><head>
		<meta name="viewport" content="width=device-width, initial-scale=1">
		<meta charset="utf-8">
		<title>Application Error</title>
		<style media="screen">
		  html,body,iframe {
			margin: 0;
			padding: 0;
		  }
		  html,body {
			height: 100%;
			overflow: hidden;
		  }
		  iframe {
			width: 100%;
			height: 100%;
			border: 0;
		  }
		</style>
	  </head>
	  <body>
		<iframe src="//www.herokucdn.com/error-pages/application-error.html"></iframe>

	</body></html>
```

so we check the page title to find if we're there.