### PR TITLE
MAImmunization parsing city incorrectly

### DIFF
--- a/data/sites.json
+++ b/data/sites.json
@@ -1,7 +1,6 @@
 {
     "MAImmunizations": {
-        "xwebsite": "https://www.maimmunizations.org/clinic/search",
-      "website": "https://www.maimmunizations.org/clinic/search?location=&search_radius=All&q%5Bvenue_search_name_or_venue_name_i_cont%5D=&q%5Bclinic_date_gteq%5D=&q%5Bvaccinations_name_i_cont%5D=&commit=Search#search_results",
+        "website": "https://www.maimmunizations.org/clinic/search?q%5Bservices_name_in%5D%5B%5D=Vaccination&location=&search_radius=All&q%5Bvenue_search_name_or_venue_name_i_cont%5D=&q%5Bclinic_date_gteq%5D=&q%5Bvaccinations_name_i_cont%5D=&commit=Search&page=1#search_results",
         "baseWebsite": "https://www.maimmunizations.org"
     },
     "UMassAmherst": {

--- a/site-scrapers/MAImmunizations.js
+++ b/site-scrapers/MAImmunizations.js
@@ -43,11 +43,13 @@ async function ScrapeWebsiteData(browser) {
 			const date = title.substring(onIndex + 4);
 
 			//address like [STREET], [CITY] MA, [ZIP]
+			//address like [STREET], [CITY] Ma, [ZIP]
+			//address like [STREET], [CITY] Massachusetts, [ZIP]
 			const firstCommaIndex = address.indexOf(", ");
 			const street = address.substring(0, firstCommaIndex);
-			let stateIndex = address.indexOf(" MA");
+			let stateIndex = address.toUpperCase().indexOf(" MA,");
 			if (stateIndex == -1) {
-				stateIndex = address.indexOf(" Massachusetts");
+				stateIndex = address.toUpperCase().indexOf(" MASSACHUSETTS");
 			}
 			const city = address.substring(firstCommaIndex + 2, stateIndex);
 			const [zip] = address.substring(stateIndex).match(/\d+/);

--- a/site-scrapers/MAImmunizations.js
+++ b/site-scrapers/MAImmunizations.js
@@ -1,9 +1,9 @@
 const sites = require("../data/sites.json");
 
 module.exports = async function GetAvailableAppointments(browser) {
-	console.log("MA starting.");
+	console.log("MAImmunizations starting.");
 	const webData = await ScrapeWebsiteData(browser);
-	console.log("MA done.");
+	console.log("MAImmunizations done.");
 	return Object.values(webData);
 };
 
@@ -21,7 +21,7 @@ async function ScrapeWebsiteData(browser) {
 	//for each page, scrape locations and available appointments.
 	for (let pageNumber = 1; pageNumber <= maxPage; pageNumber++) {
 		if (pageNumber != 1) {
-			await page.goto(sites.MAImmunizations.website + "?page=" + pageNumber);
+			await page.goto(sites.MAImmunizations.website.replace("page=1", "page="+pageNumber));
 		}
 
 		const entries = await page.$$("div.justify-between.border-b");
@@ -43,17 +43,14 @@ async function ScrapeWebsiteData(browser) {
 			const date = title.substring(onIndex + 4);
 
 			//address like [STREET], [CITY] MA, [ZIP]
+			//address like [STREET], [CITY] MA [ZIP]
 			//address like [STREET], [CITY] Ma, [ZIP]
 			//address like [STREET], [CITY] Massachusetts, [ZIP]
 			const firstCommaIndex = address.indexOf(", ");
 			const street = address.substring(0, firstCommaIndex);
-			let stateIndex = address.toUpperCase().indexOf(" MA,");
-			if (stateIndex == -1) {
-				stateIndex = address.toUpperCase().indexOf(" MASSACHUSETTS");
-			}
+			let stateIndex = address.toUpperCase().lastIndexOf(" MA");
 			const city = address.substring(firstCommaIndex + 2, stateIndex);
 			const [zip] = address.substring(stateIndex).match(/\d+/);
-
 			const extraData = {};
 			let availableAppointments = 0;
 			rawExtraData.forEach((text) => {


### PR DESCRIPTION
Greenfield Senior Center on 02/19/2021
35 Pleasant Street, Greenfield ma, 01301

It was incorrectly parsing as { street : "35 Pleasant Street", city:"35 Pleasant Street" }

The previous code was doing a case-sensitive search for " MA" or " Massachusetts" as the state.

1. I changed to the be case-insensitive.
2. Changed first search to " MA," (with the added comma) so as not to die on "123 Main St, Malden MA, 02148"