### PR TITLE
Correctly parse CVS's Mountain timestamp

### DIFF
--- a/site-scrapers/CVS.js
+++ b/site-scrapers/CVS.js
@@ -19,7 +19,6 @@ module.exports = async function GetAvailableAppointments(browser) {
             //TODO: fix this better
             timestamp.getTime() + 7 * 60 * 60 * 1000 //add 7 hrs to go from UTC to Eastern
         );
-        console.log(timestamp);
         return {
             name: `${siteName} (${responseLocation.city})`,
             hasAvailability,

--- a/site-scrapers/CVS.js
+++ b/site-scrapers/CVS.js
@@ -7,6 +7,24 @@ module.exports = async function GetAvailableAppointments(browser) {
     console.log(`${siteName} starting.`);
     const webData = await ScrapeWebsiteData(browser);
     console.log(`${siteName} done.`);
+    // Javascript is not good at timezones. CVS's timestamp arrives in
+    // US/Mountain time, and we need to convert it to UTC. Since the offset
+    // changes twice a year, we need to calculate the current offset, and then
+    // parse CVS's currentTime using it.
+    // The best we can do is render the time in two timezones, parse those as dates
+    // and subtract them, and convert them from milliseconds to hours.
+    const now = new Date(); // 2021-02-20T04:52:15.444Z
+    const offsetMountain =
+        ["US/Mountain", "UTC"]
+            .map((z) =>
+                Date.parse(now.toLocaleString("en-US", { timeZone: z }))
+            )
+            .reduce((a, b) => b - a) /
+        (3600 * 1000);
+    // This would fail if offsetMountain were 2 digits, but it will only ever be 6 or 7.
+    const timestamp = new Date(
+        `${webData.responsePayloadData.currentTime}-0${offsetMountain}:00`
+    );
     return webData.responsePayloadData.data.MA.map((responseLocation) => {
         let hasAvailability = parseInt(responseLocation.totalAvailable)
             ? true
@@ -14,11 +32,6 @@ module.exports = async function GetAvailableAppointments(browser) {
         let totalAvailability = parseInt(responseLocation.totalAvailable);
         let availability = {};
         responseLocation.city = toTitleCase(responseLocation.city);
-        let timestamp = new Date(webData.responsePayloadData.currentTime);
-        timestamp = new Date(
-            //TODO: fix this better
-            timestamp.getTime() + 7 * 60 * 60 * 1000 //add 7 hrs to go from UTC to Eastern
-        );
         return {
             name: `${siteName} (${responseLocation.city})`,
             hasAvailability,


### PR DESCRIPTION
Unfortunately timezone offsets are not fixed and Mountain time will
change by 1 hour on March 14, which is soon enough that we do care.

Javascript's timezone support is extremely spotty. Without bringing in
a library like moment.js and all the hair that implies, this is about
the best we can do.

To calculate the timezone offset, we render the current datetime as
local time in the two timezones, and then subtract them and convert
from milliseconds to hours, and append the numeric timezone offset
to the returned timestring that is fed to the Date() constructor.

I am so, so, sorry.

* Also: don't console.log every timestamp