### PR TITLE
Cachebus CVS to avoid Akamai caching

### DIFF
--- a/site-scrapers/CVS.js
+++ b/site-scrapers/CVS.js
@@ -54,28 +54,22 @@ function toTitleCase(str) {
         .join(" ");
 }
 
+function urlContent(url, options) {
+    return new Promise((resolve) => {
+        let response = "";
+        https.get(url, options, (res) => {
+            let body = "";
+            res.on("data", (chunk) => (body += chunk));
+            res.on("end", () => {
+                response = body;
+                resolve(response);
+            });
+        });
+    });
+}
+
 async function ScrapeWebsiteData(browser) {
     const url = site.massJson;
-    const getUrl = new Promise((resolve) => {
-        let response = "";
-        https.get(
-            url,
-            {
-                headers: {
-                    Referer:
-                        "https://www.cvs.com/immunizations/covid-19-vaccine",
-                },
-            },
-            (res) => {
-                let body = "";
-                res.on("data", (chunk) => (body += chunk));
-                res.on("end", () => {
-                    response = JSON.parse(body);
-                    resolve(response);
-                });
-            }
-        );
-    });
-    const responseJson = await getUrl;
-    return responseJson;
+    const options = { headers: { Referer: site.website } };
+    return JSON.parse(await urlContent(url, options));
 }

--- a/site-scrapers/CVS.js
+++ b/site-scrapers/CVS.js
@@ -69,7 +69,13 @@ function urlContent(url, options) {
 }
 
 async function ScrapeWebsiteData(browser) {
-    const url = site.massJson;
+    // Simply retrieving
+    //   https://www.cvs.com/immunizations/covid-19-vaccine.vaccine-status.ma.json?vaccineinfo
+    // returns potentially stale data that varies based on the Akamai Edgekey server that you access.
+    // Append a cachebusting
+    //   &nonce=&nonce=1613934207668
+    // to bypass Akamai caching.
+    const url = `${site.massJson}&nonce=${new Date().valueOf()}`;
     const options = { headers: { Referer: site.website } };
     return JSON.parse(await urlContent(url, options));
 }


### PR DESCRIPTION
Ugh, I totally forgot about this issue when reviewing CVS, and I hope this approach is not too heavy-handed.
cvs.com uses Akamai's EdgeKey servers for caching, and sometimes they can cache several hours-old information.
Which server you get depends on the time of day and where you are in the network. For instance, querying 4 different Akamai servers for cvs.com, I get these different levels of recency:

```
pb3:~ jhawk$ edgekeys="104.77.232.71 104.96.103.31 23.197.182.22 23.46.189.181"
pb3:~ jhawk$ for e in $edgekeys; do
  echo -n "$e "
   curl -s --resolve www.cvs.com:443:$e  \
     -H 'Referer: https://www.cvs.com/immunizations/covid-19-vaccine' \
    https://www.cvs.com/immunizations/covid-19-vaccine.vaccine-status.ma.json |
  jq .[].currentTime
done
104.77.232.71 "2021-02-21T06:54:35.052"
null
104.96.103.31 "2021-02-21T13:04:02.593"
null
23.197.182.22 "2021-02-21T06:54:35.052"
null
23.46.189.181 "2021-02-21T06:54:35.052"
null
```

That is, 3 servers return data that's 6 hours older than the best one.

Adding a cachebusting nonce resolves this, no matter which cvs.com you ask:

```
pb3:~ jhawk$ for e in $edgekeys; do
   echo -n "$e "
  curl -s --resolve www.cvs.com:443:$e \
    -H 'Referer: https://www.cvs.com/immunizations/covid-19-vaccine'  \
    https://www.cvs.com/immunizations/covid-19-vaccine.vaccine-status.ma.json'?nonce=1505jhawk' |
  jq .[].currentTime
done
104.77.232.71 "2021-02-21T13:00:00.535"
null
104.96.103.31 "2021-02-21T13:05:42.662"
null
23.197.182.22 "2021-02-21T13:00:00.535"
null
23.46.189.181 "2021-02-21T13:00:00.535"
```

well, sort-of :) Or we're better with a unique nonce:
```
pb3:~ jhawk$ for e in $edgekeys; do
  echo -n "$e "
  curl -s --resolve www.cvs.com:443:$e  \
    -H 'Referer: https://www.cvs.com/immunizations/covid-19-vaccine'  \
    https://www.cvs.com/immunizations/covid-19-vaccine.vaccine-status.ma.json'?nonce=1505jhawk'"$e" |
  jq .[].currentTime
done
104.77.232.71 "2021-02-21T13:06:14.176"
null
104.96.103.31 "2021-02-21T13:06:15.124"
null
23.197.182.22 "2021-02-21T13:05:00.528"
null
23.46.189.181 "2021-02-21T13:06:16.633"
```

All within 16 seconds.

(I am not an Akamai Edgekey expert, and I can't really explain this last behavior.)

Unfortunately, I could not figure out how to make this work with Puppeteer — appending `"&nonce=12345"` to the `page.waitForResponse()` URL caused the browser to hang and hit the 30 second timeout. That said, I'm not sure why we were using Puppeteer here at all, but this converts it to `https.get` (but a `Referer: ` header is required). I prefer a little more abstraction than what we have in the existing scrapers that use `https.get`, so I added some here (`urlContent()` returning a Promise).

p.s.: If someone wants to tell me this should all have been outlined in an Issue and the PR (and thus commit history) kept clean of rationale, I am accepting of that feedback and debated it with myself.