### PR TITLE
Atrius: Needs to actually work without redirect

### DIFF
--- a/site-scrapers/Atrius.js
+++ b/site-scrapers/Atrius.js
@@ -29,7 +29,7 @@ function urlRedirect(url, options) {
 
 async function ScrapeWebsiteData() {
     const checkSlots = await urlRedirect(sites.Atrius.website, {});
-    if (checkSlots.match("No_Slots")) {
+    if (checkSlots && checkSlots.match("No_Slots")) {
         console.log(
             `Atrius redirecting to no slots, ${checkSlots}, assuming failure!`
         );


### PR DESCRIPTION
Whoops. de1a44 made me realize that this breaks if there is no Location: header returned, then
checkSlots will be null and checkSlots.match will fail:

```
DEV MODE
Atrius starting.
TypeError: Cannot read property 'match' of undefined
    at ScrapeWebsiteData (/Users/jhawk/src/covid-vaccine-scrapers/site-scrapers/Atrius.js:32:20)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async GetAvailableAppointments (/Users/jhawk/src/covid-vaccine-scrapers/site-scrapers/Atrius.js:7:21)
    at async Promise.all (index 0)
    at async gatherData (/Users/jhawk/src/covid-vaccine-scrapers/main.js:48:25)
    at async execute (/Users/jhawk/src/covid-vaccine-scrapers/main.js:143:5)
    at async /Users/jhawk/src/covid-vaccine-scrapers/main.js:151:9
The following data would be published:
```

Guard checkSlots before matching.