### PR TITLE
Walgreens using fetch

### DIFF
--- a/site-scrapers/Walgreens.js
+++ b/site-scrapers/Walgreens.js
@@ -78,7 +78,7 @@ async function ScrapeWebsiteData(browser) {
                     fetch(
                         "https://www.walgreens.com/hcschedulersvc/svc/v2/immunizationLocations/timeslots",
                         {
-                            method: "POST", // or 'PUT'
+                            method: "POST",
                             headers: {
                                 "Content-Type": "application/json",
                             },

--- a/site-scrapers/Walgreens.js
+++ b/site-scrapers/Walgreens.js
@@ -75,13 +75,14 @@ async function ScrapeWebsiteData(browser) {
         let postResponse = await page.evaluate(
             (latitude, longitude, todayString) =>
                 new Promise((resolve) => {
-                    jQuery
-                        .ajax({
-                            url:
-                                "https://www.walgreens.com/hcschedulersvc/svc/v2/immunizationLocations/timeslots",
-                            type: "POST",
-                            dataType: "json",
-                            data: JSON.stringify({
+                    fetch(
+                        "https://www.walgreens.com/hcschedulersvc/svc/v2/immunizationLocations/timeslots",
+                        {
+                            method: "POST", // or 'PUT'
+                            headers: {
+                                "Content-Type": "application/json",
+                            },
+                            body: JSON.stringify({
                                 position: {
                                     latitude: latitude,
                                     longitude: longitude,
@@ -95,15 +96,15 @@ async function ScrapeWebsiteData(browser) {
                                 serviceId: "99",
                                 state: "MA",
                             }),
-                            contentType: "application/json",
+                        }
+                    )
+                        .then((response) => response.json())
+                        .then((data) => {
+                            resolve(data); // fetch won't reject 404 or 500
                         })
-                        .then(
-                            (res) => resolve(res),
-                            (err) => {
-                                // service throws 404 if no appts found
-                                resolve(); // resolve promise without  `err` or else puppeteer fails
-                            }
-                        );
+                        .catch((error) => {
+                            resolve(error); // only happens on network failure
+                        });
                 }),
             latitude,
             longitude,


### PR DESCRIPTION
Fetch handles 404 and 500 errors from APIs a bit differently than jQuery see: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch and it removes our reliance on jQuery in case Walgreens decides to no longer expose it or removes it from their page.

@livgust LMK that you think. Considering this WIP for now since I don't have a Walgreens appointment available JSON sample to make sure the fetch response doesn't change `postResponse` in some way.