### PR TITLE
CVS.js: Handle reduced JSON

### DIFF
--- a/site-scrapers/CVS.js
+++ b/site-scrapers/CVS.js
@@ -47,20 +47,21 @@ module.exports = async function GetAvailableAppointments(browser) {
         // availability.
         // Also, we had previously seen cases where numeric availability was "0" but status
         // was "Available" and it's not apparent what that really meant (skew? bugs?).
-        responseLocation.city = toTitleCase(responseLocation.city);
-        responseLocation.name = `${siteName} (${responseLocation.city})`;
-        responseLocation.hasAvailability =
-            responseLocation.status !== "Fully Booked";
         let totalAvailability =
             responseLocation.totalAvailable &&
             parseInt(responseLocation.totalAvailable);
+        const retval = {
+            city: toTitleCase(responseLocation.city),
+            name: `${siteName} (${responseLocation.city})`,
+            hasAvailability: responseLocation.status !== "Fully Booked",
+            availability: {},
+            timestamp: timestamp,
+            signUpLink: site.website,
+        };
         if (totalAvailability) {
-            responseLocation.totalAvailability = totalAvailability;
+            retval.totalAvailability = totalAvailability;
         }
-        responseLocation.availability = {};
-        responseLocation.timestamp = timestamp;
-        responseLocation.signUpLink = site.website;
-        return responseLocation;
+        return retval;
     });
 };
 

--- a/site-scrapers/CVS.js
+++ b/site-scrapers/CVS.js
@@ -47,7 +47,7 @@ module.exports = async function GetAvailableAppointments(browser) {
         // availability.
         // Also, we had previously seen cases where numeric availability was "0" but status
         // was "Available" and it's not apparent what that really meant (skew? bugs?).
-        let totalAvailability =
+        const totalAvailability =
             responseLocation.totalAvailable &&
             parseInt(responseLocation.totalAvailable);
         const retval = {

--- a/site-scrapers/CVS.js
+++ b/site-scrapers/CVS.js
@@ -50,9 +50,10 @@ module.exports = async function GetAvailableAppointments(browser) {
         const totalAvailability =
             responseLocation.totalAvailable &&
             parseInt(responseLocation.totalAvailable);
+        const city = toTitleCase(responseLocation.city);
         const retval = {
-            city: toTitleCase(responseLocation.city),
-            name: `${siteName} (${responseLocation.city})`,
+            city: city,
+            name: `${siteName} (${city})`,
             hasAvailability: responseLocation.status !== "Fully Booked",
             availability: {},
             timestamp: timestamp,

--- a/site-scrapers/CVS.js
+++ b/site-scrapers/CVS.js
@@ -28,10 +28,29 @@ module.exports = async function GetAvailableAppointments(browser) {
         `${webData.responsePayloadData.currentTime}-0${offsetMountain}:00`
     );
     return webData.responsePayloadData.data.MA.map((responseLocation) => {
-        let hasAvailability = parseInt(responseLocation.totalAvailable)
-            ? true
-            : false;
-        let totalAvailability = parseInt(responseLocation.totalAvailable);
+        // Prior to Feb 22 or so, CVS's JSON returned:
+        //  {
+        //    "totalAvailable": "0",
+        //    "city": "CAMBRIDGE",
+        //    "state": "MA",
+        //    "pctAvailable": "0.00%",
+        //    "status": "Fully Booked"
+        //  },
+        //
+        // But as of Feb. 25 it returns:
+        //  {
+        //    "city": "CAMBRIDGE",
+        //    "state": "MA",
+        //    "status": "Fully Booked"
+        //  },
+        // It's not clear whether we can expect the other fields to return when there is
+        // availability.
+        // Also, we had previously seen cases where numeric availability was "0" but status
+        // was "Available" and it's not apparent what that really meant (skew? bugs?).
+        let hasAvailability = (responseLocation.status !== "Fully Booked");
+        let totalAvailability =
+            responseLocation.totalAvailable &&
+            parseInt(responseLocation.totalAvailable);
         let availability = {};
         responseLocation.city = toTitleCase(responseLocation.city);
         return {

--- a/site-scrapers/CVS.js
+++ b/site-scrapers/CVS.js
@@ -47,21 +47,20 @@ module.exports = async function GetAvailableAppointments(browser) {
         // availability.
         // Also, we had previously seen cases where numeric availability was "0" but status
         // was "Available" and it's not apparent what that really meant (skew? bugs?).
-        let hasAvailability = (responseLocation.status !== "Fully Booked");
+        responseLocation.city = toTitleCase(responseLocation.city);
+        responseLocation.name = `${siteName} (${responseLocation.city})`;
+        responseLocation.hasAvailability =
+            responseLocation.status !== "Fully Booked";
         let totalAvailability =
             responseLocation.totalAvailable &&
             parseInt(responseLocation.totalAvailable);
-        let availability = {};
-        responseLocation.city = toTitleCase(responseLocation.city);
-        return {
-            name: `${siteName} (${responseLocation.city})`,
-            hasAvailability,
-            availability,
-            totalAvailability,
-            timestamp: timestamp,
-            signUpLink: site.website,
-            ...responseLocation,
-        };
+        if (totalAvailability) {
+            responseLocation.totalAvailability = totalAvailability;
+        }
+        responseLocation.availability = {};
+        responseLocation.timestamp = timestamp;
+        responseLocation.signUpLink = site.website;
+        return responseLocation;
     });
 };
 


### PR DESCRIPTION
# CVS.js: Handle reduced JSON

In the past few days CVS's JSON stopped returning numeric availability information
("totalAvailable" and "pctAvailable" keys). This didn't exactly "break" the scraper, but
it causedit to do goofy things like return NaN for availability (but there was none).

Revise the scraper to return a claim of availability as long as CVS
does not say "Fully Booked." Note that in the past, we've seen claims
of boolean availability with claims of "0" numeric availability, and
it's not apparent what that meant. But now we don't really have a choice.

Don't try to parse totalAvailable if it doesn't exist (leads to NaN).

Document the JSON form a bit better in a comment.

## CVS.js: Avoid undefineds: don't use spread (...) syntax

Previously, we took CVS's returned JSON object and added properties to it with
JS's spread (...) syntax in a filter, as:
```
  return { newprop1: newvalue1, newprop2, ... originalObject };
```

Unfortunately, that makes it impossible to suppress `newprop2` if,
e.g., it is `undefined`, as with `totalAvailability` here.

So, we revert to inelegance and instead
    
So, we revert to inelegance and instead

```
  r.newprop1 = newvalue1;
  if (newprop2) { r.newprop2 = newprop2 }
  return r;
```