### PR TITLE
Fix screenshot to capture full page

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -92,7 +92,7 @@ async function savePageContent(siteName, page) {
     const s3Dir = "debug";
     if (process.env.DEVELOPMENT) {
         file.write(htmlFileName, html);
-        await page.screenshot({ path: screenshotFileName });
+        await page.screenshot({ path: screenshotFileName, fullPage: true });
     } else {
         const pngDataBuffer = await page.screenshot();
         await uploadFile(s3Dir, screenshotFileName, pngDataBuffer);


### PR DESCRIPTION
If the page has scrollable content, screenshot only captured the first section. With the 'fullPage' option set to true, it now captures the entire page.