### PR TITLE
CVSPharmacy: Return time of scrape, not site's time

### DIFF
--- a/site-scrapers/CVSPharmacy/index.js
+++ b/site-scrapers/CVSPharmacy/index.js
@@ -54,7 +54,8 @@ module.exports = async function GetAvailableAppointments(browser) {
             name: `${site.name} (${city})`,
             hasAvailability: responseLocation.status !== "Fully Booked",
             availability: {},
-            timestamp: timestamp,
+            timestamp: new Date(),
+            siteTimestamp: timestamp,
             signUpLink: site.website,
         };
         if (totalAvailability) {


### PR DESCRIPTION
Alas, for elegance! After discussion at this morning's standup,
conclude that with the current UI, we should return the time we
scrape, rather than the time CVS reports, because it makes our data
looks older than it really is.

Return CVS's timestamp as `siteTimestamp`. Another choice is to return
it in `extraData`, but we're not confident we want to show it now.