### PR TITLE
MAImmunization: "more information" has blank line

### DIFF
--- a/site-scrapers/MAImmunizations/index.js
+++ b/site-scrapers/MAImmunizations/index.js
@@ -49,7 +49,7 @@ async function ScrapeWebsiteData(browser) {
             const rawData = [];
             for (const element of rawDataElements) {
                 const text = await element.evaluate((node) => node.innerText);
-                if (text.length) {
+                if (text?.length) {
                     rawData.push(text);
                 }
             }

--- a/site-scrapers/MAImmunizations/index.js
+++ b/site-scrapers/MAImmunizations/index.js
@@ -49,7 +49,9 @@ async function ScrapeWebsiteData(browser) {
             const rawData = [];
             for (const element of rawDataElements) {
                 const text = await element.evaluate((node) => node.innerText);
-                rawData.push(text);
+                if (text.length) {
+                    rawData.push(text);
+                }
             }
             const [title, address, ...rawExtraData] = rawData;
 


### PR DESCRIPTION
Malformed HTML in the source site has an unclosed  `<p>` that is creating an empty line in our "More Information" accordion.

>             <p>
>                 <strong>Age groups served:</strong>
>                 Seniors, Other
>             </p>
>             <p>
>             <p>
>                 <strong>Services offered:</strong>
>                 Vaccination
>             </p>

![image](https://user-images.githubusercontent.com/546007/111870408-f4ad6b80-895a-11eb-937d-5af1f9d9d182.png)
