### PR TITLE
Added "massVax" flag set to true for all Color & Curative sites.

### DIFF
--- a/site-scrapers/Color/config.js
+++ b/site-scrapers/Color/config.js
@@ -6,6 +6,7 @@ const sites = [
         zip: "01760",
         signUpLink: "https://home.color.com/vaccine/register/natickmall",
         siteUrl: "Natick%20Mall",
+        massVax: true, // This is a MassVax site that only allows preregistration
     },
     {
         name: "Gillette Stadium - East",
@@ -14,6 +15,7 @@ const sites = [
         zip: "02035",
         signUpLink: "https://home.color.com/vaccine/register/gillettestadium",
         siteUrl: "Gillette%20Stadium%20-%20East",
+        massVax: true, // This is a MassVax site that only allows preregistration
     },
     {
         name: "Gillette Stadium - West",
@@ -22,6 +24,7 @@ const sites = [
         zip: "02035",
         signUpLink: "https://home.color.com/vaccine/register/gillettestadium",
         siteUrl: "Gillette%20Stadium%20-%20West",
+        massVax: true, // This is a MassVax site that only allows preregistration
     },
     {
         name: "Reggie Lewis State Track Athletic Center",
@@ -30,6 +33,7 @@ const sites = [
         zip: "02120",
         signUpLink: "https://home.color.com/vaccine/register/reggielewis",
         siteUrl: "Reggie%20Lewis%20Center",
+        massVax: true, // This is a MassVax site that only allows preregistration
     },
     {
         name: "Fenway Park",
@@ -38,6 +42,7 @@ const sites = [
         zip: "02215",
         signUpLink: "https://home.color.com/vaccine/register/fenway-hynes",
         siteUrl: "Fenway%20Park",
+        massVax: true, // This is a MassVax site that only allows preregistration
     },
     {
         name: "Hynes Convention Center",
@@ -46,6 +51,7 @@ const sites = [
         city: "Boston",
         zip: "02115",
         signUpLink: "https://home.color.com/vaccine/register/fenway-hynes",
+        massVax: true, // This is a MassVax site that only allows preregistration
     },
 ];
 

--- a/site-scrapers/Color/index.js
+++ b/site-scrapers/Color/index.js
@@ -46,43 +46,56 @@ async function ScrapeWebsiteData(siteName, siteUrl) {
 
 function formatResponse(availabilityResponse) {
     const availability = JSON.parse(availabilityResponse).results;
-    const results = { availability: {}, hasAvailability: false };
-    /* COMMENTING OUT BECAUSE IT'S NOW INVITE-ONLY */
-    // Collect availability count by date
-    //  availability.reduce((memo, currentValue) => {
-    //     /* The availability returns an array of appointments like this:
-    //         {
-    //             "start": "2021-02-22T14:00:00+00:00",
-    //             "end": "2021-02-22T14:04:00+00:00",
-    //             "capacity": 1,
-    //             "remaining_spaces": -1
+    const results = {
+        massVax: true, // This is a MassVax site that only allows preregistration
+        hasAvailability: false,
+        availability: {},
+    };
 
-    //         }
-    //     */
-    //     let remainingSpaces = currentValue["remaining_spaces"];
-    //     if (remainingSpaces > 0) {
-    //         const appointmentDateGMT = new Date(currentValue["start"]);
-    //         let appointmentDateET = appointmentDateGMT.toLocaleString("en-US", {
-    //             timeZone: "America/New_York",
-    //         });
-    //         appointmentDateET = appointmentDateET.substring(
-    //             0,
-    //             appointmentDateET.indexOf(",")
-    //         );
-    //         let dateAvailability = memo["availability"][appointmentDateET];
-    //         if (!dateAvailability) {
-    //             dateAvailability = {
-    //                 numberAvailableAppointments: 0,
-    //                 hasAvailability: false,
-    //             };
-    //             memo["availability"][appointmentDateET] = dateAvailability;
-    //         }
-    //         dateAvailability["numberAvailableAppointments"] += remainingSpaces;
-    //         dateAvailability["hasAvailability"] = true;
-    //         memo["hasAvailability"] = true;
-    //     }
-    //     return memo;
-    // }, results);
+    // If this is a massVax site that is invite-only, then we don't
+    // need availability data.
+    if (!results.massVax) {
+        // Collect availability count by date
+        availability.reduce((memo, currentValue) => {
+            /* The availability returns an array of appointments like this:
+                {
+                    "start": "2021-02-22T14:00:00+00:00",
+                    "end": "2021-02-22T14:04:00+00:00",
+                    "capacity": 1,
+                    "remaining_spaces": -1
+    
+                }
+            */
+            let remainingSpaces = currentValue["remaining_spaces"];
+            if (remainingSpaces > 0) {
+                const appointmentDateGMT = new Date(currentValue["start"]);
+                let appointmentDateET = appointmentDateGMT.toLocaleString(
+                    "en-US",
+                    {
+                        timeZone: "America/New_York",
+                    }
+                );
+                appointmentDateET = appointmentDateET.substring(
+                    0,
+                    appointmentDateET.indexOf(",")
+                );
+                let dateAvailability = memo["availability"][appointmentDateET];
+                if (!dateAvailability) {
+                    dateAvailability = {
+                        numberAvailableAppointments: 0,
+                        hasAvailability: false,
+                    };
+                    memo["availability"][appointmentDateET] = dateAvailability;
+                }
+                dateAvailability[
+                    "numberAvailableAppointments"
+                ] += remainingSpaces;
+                dateAvailability["hasAvailability"] = true;
+                memo["hasAvailability"] = true;
+            }
+            return memo;
+        }, results);
+    }
     return results;
 }
 

--- a/site-scrapers/Curative/config.js
+++ b/site-scrapers/Curative/config.js
@@ -5,12 +5,15 @@ const site = {
     locations: [
         {
             id: 24181,
+            massVax: true, // This is a MassVax site that only allows preregistration
         },
         {
             id: 24182,
+            massVax: true, // This is a MassVax site that only allows preregistration
         },
         {
             id: 25336,
+            massVax: true, // This is a MassVax site that only allows preregistration
         },
     ],
 };

--- a/site-scrapers/Curative/index.js
+++ b/site-scrapers/Curative/index.js
@@ -37,7 +37,7 @@ module.exports = async function GetAvailableAppointments(browser) {
             city: data.city,
             zip: data.postal_code,
             signUpLink: site.linkWebsite + loc.id,
-            massVax: true, // This is a MassVax site that only allows preregistration
+            massVax: !!loc.massVax, // This is a MassVax site that only allows preregistration
             hasAvailability: false,
             availability: {}, //date (MM/DD/YYYY) => hasAvailability, numberAvailableAppointments
             timestamp: new Date(),

--- a/site-scrapers/Curative/index.js
+++ b/site-scrapers/Curative/index.js
@@ -26,7 +26,7 @@ module.exports = async function GetAvailableAppointments(browser) {
     console.log(`${site.name} (basically) done.`);
     return site.locations.map((loc) => {
         const data = rawData[loc.id];
-        const mappedData = {
+        const results = {
             id: loc.id,
             name: data.name,
             street: (
@@ -37,50 +37,53 @@ module.exports = async function GetAvailableAppointments(browser) {
             city: data.city,
             zip: data.postal_code,
             signUpLink: site.linkWebsite + loc.id,
+            massVax: true, // This is a MassVax site that only allows preregistration
             hasAvailability: false,
             availability: {}, //date (MM/DD/YYYY) => hasAvailability, numberAvailableAppointments
             timestamp: new Date(),
         };
-        /* COMMENTING OUT BELOW BECAUSE APPTS ARE INVITE-ONLY */
-        // data.appointment_windows.forEach((appointment) => {
-        //     const dateRegexp = /(?<year>[0-9]{4})-(?<month>[0-9]{2})-(?<day>[0-9]{2})/;
-        //     const { year, month, day } = appointment.start_time.match(
-        //         dateRegexp
-        //     ).groups;
-        //     const date = `${month}/${day}/${year}`;
-        //     let newNumberAvailable =
-        //         appointment.status !== "Disabled"
-        //             ? appointment.slots_available
-        //             : 0;
+        // If this is a massVax site that is invite-only, then we don't
+        // need availability data.
+        if (!results.massVax) {
+            data.appointment_windows.forEach((appointment) => {
+                const dateRegexp = /(?<year>[0-9]{4})-(?<month>[0-9]{2})-(?<day>[0-9]{2})/;
+                const { year, month, day } = appointment.start_time.match(
+                    dateRegexp
+                ).groups;
+                const date = `${month}/${day}/${year}`;
+                let newNumberAvailable =
+                    appointment.status !== "Disabled"
+                        ? appointment.slots_available
+                        : 0;
 
-        //     if (newNumberAvailable) {
-        //         mappedData.hasAvailability = true;
-        //     }
+                if (newNumberAvailable) {
+                    results.hasAvailability = true;
+                }
 
-        //     if (mappedData.availability[date]) {
-        //         newNumberAvailable +=
-        //             mappedData.availability[date].numberAvailableAppointments;
-        //     }
+                if (results.availability[date]) {
+                    newNumberAvailable +=
+                        results.availability[date].numberAvailableAppointments;
+                }
 
-        //     // Only add date keys if there are appointments
-        //     if (newNumberAvailable) {
-        //         mappedData.availability[date] = {
-        //             numberAvailableAppointments: newNumberAvailable,
-        //             hasAvailability: true,
-        //         };
-        //     }
-        // });
+                // Only add date keys if there are appointments
+                if (newNumberAvailable) {
+                    results.availability[date] = {
+                        numberAvailableAppointments: newNumberAvailable,
+                        hasAvailability: true,
+                    };
+                }
+            });
 
-        // if (
-        //     data.hasOwnProperty("visible_in_search") &&
-        //     !data.visible_in_search
-        // ) {
-        //     // Commented out the following line because there is currently a
-        //     // waiting room for people to join for an event that starts at 8:30am.
-        //     // We should revisit this later after the appointments are gone.
-        //     //mappedData.hasAvailability = false;
-        // }
-
-        return mappedData;
+            if (
+                data.hasOwnProperty("visible_in_search") &&
+                !data.visible_in_search
+            ) {
+                // Commented out the following line because there is currently a
+                // waiting room for people to join for an event that starts at 8:30am.
+                // We should revisit this later after the appointments are gone.
+                //results.hasAvailability = false;
+            }
+        }
+        return results;
     });
 };


### PR DESCRIPTION
The front-end will be able to present a better UX with this information.

Note: I uncommented the availability data retrieval code that was removed recently when these became invitation-only Preregistration sites.  It still isn't returning this data, but decides to skip the code based on the massVax flag.

If these sites revert to "no invitation required" in a future with ample vaccine supply, then we only need to change "massVax" to false again.