### PR TITLE
removing escaping json in response

### DIFF
--- a/getScraperData.js
+++ b/getScraperData.js
@@ -12,7 +12,7 @@ exports.handler = async () => {
 
     const response = {
         statusCode: 200,
-        body: data.Body.toString(),
+        body: JSON.parse(data.Body.toString()),
     };
     return response;
 };


### PR DESCRIPTION
Tested on my own lambda, this should solve the issue where the API returns a string as the body of the `prod` response. DO NOT ACCEPT until https://github.com/livgust/macovidvaccines.com/pull/164 has been merged as it need a corresponding UI change to handle just JSON.