### PR TITLE
log EastBoston fetch result, update some params

### DIFF
--- a/site-scrapers/EastBostonNHC/config.js
+++ b/site-scrapers/EastBostonNHC/config.js
@@ -4,10 +4,10 @@ const site = {
         "https://patient.lumahealth.io/survey?patientFormTemplate=601d6aec4f308f00128eb4cd&user=600f45213901d90012deb171",
     locations: [
         {
-            street: "10 Garofalo St",
+            street: "1290 N Shore Road",
             city: "Revere",
             zip: "02151",
-            // facility_id: "6011f3c1fa2b92009a1c0e28", // Leaving facility_id in case we want to query by location in the future.
+            // facility_id: "6011f3c1fa2b92009a1c0e26", // Leaving facility_id in case we want to query by location in the future.
         },
         {
             street: "318 Broadway",

--- a/site-scrapers/EastBostonNHC/index.js
+++ b/site-scrapers/EastBostonNHC/index.js
@@ -69,9 +69,12 @@ async function fetchResponse({ url, method, headers, body }) {
         headers,
     })
         .then(
+            (res) => {
+                console.log("logging res from fetch", res);
+                return res;
+            },
             (res) => res.json(),
             (err) => {
-                console.log("logging res from fetch", res);
                 console.error(err);
                 return null;
             }

--- a/site-scrapers/EastBostonNHC/index.js
+++ b/site-scrapers/EastBostonNHC/index.js
@@ -29,6 +29,7 @@ async function GetAllAvailability(availabilityService) {
     const rawAvailability = await availabilityService.getAvailabilityResponse(
         accessToken
     );
+    console.log("rawAvail", rawAvailability);
     return rawAvailability.response.reduce((acc, appointment) => {
         const zip = appointment.facility.postcode;
         const date = appointment.date.split("T")[0]; // get 2021-03-08 from 2021-03-08T22:40:00.000Z
@@ -68,17 +69,12 @@ async function fetchResponse({ url, method, headers, body }) {
         body,
         headers,
     })
-        .then(
-            (res) => {
-                console.log("logging res from fetch", res);
-                return res;
-            },
-            (res) => res.json(),
-            (err) => {
-                console.error(err);
-                return null;
-            }
-        );
+        .then((res) => res.text())
+        .then((textRes) => {
+            console.log("Received:", textRes);
+            return JSON.parse(textRes);
+        })
+        .catch(console.error);
 }
 
 function getAvailabilityService() {

--- a/site-scrapers/EastBostonNHC/index.js
+++ b/site-scrapers/EastBostonNHC/index.js
@@ -29,7 +29,6 @@ async function GetAllAvailability(availabilityService) {
     const rawAvailability = await availabilityService.getAvailabilityResponse(
         accessToken
     );
-    console.log("rawAvail", rawAvailability);
     return rawAvailability.response.reduce((acc, appointment) => {
         const zip = appointment.facility.postcode;
         const date = appointment.date.split("T")[0]; // get 2021-03-08 from 2021-03-08T22:40:00.000Z
@@ -71,8 +70,12 @@ async function fetchResponse({ url, method, headers, body }) {
     })
         .then((res) => res.text())
         .then((textRes) => {
-            console.log("Received:", textRes);
-            return JSON.parse(textRes);
+            try {
+                return JSON.parse(textRes);
+            } catch (err) {
+                console.error("Failed to parse response", textRes, err);
+                throw err;
+            }
         })
         .catch(console.error);
 }

--- a/site-scrapers/EastBostonNHC/index.js
+++ b/site-scrapers/EastBostonNHC/index.js
@@ -67,13 +67,15 @@ async function fetchResponse({ url, method, headers, body }) {
         method,
         body,
         headers,
-    }).then(
-        (res) => res.json(),
-        (err) => {
-            console.error(err);
-            return null;
-        }
-    );
+    })
+        .then(
+            (res) => res.json(),
+            (err) => {
+                console.log("logging res from fetch", res);
+                console.error(err);
+                return null;
+            }
+        );
 }
 
 function getAvailabilityService() {
@@ -99,21 +101,22 @@ function getAvailabilityService() {
             return await fetchResponse({
                 url: [
                     "https://api.lumahealth.io/api/scheduler/availabilities?appointmentType=6011f3c4fa2b92009a1c0f43",
-                    `date=%3E${startDate}T00%3A00%3A00-05%3A00`,
+                    `date=%3E${startDate}T00%3A00%3A00-04%3A00`,
                     `date=%3C${endDate}T23%3A59%3A59-04%3A00`,
-                    "facility=6011f3c1fa2b92009a1c0e28%2C6011f3c1fa2b92009a1c0e24%2C601a236ff7f880001333e993%2C601a236ff7f880001333e993%2C6011f3c1fa2b92009a1c0e2a",
+                    "facility=6011f3c1fa2b92009a1c0e26%2C6011f3c1fa2b92009a1c0e24%2C601a236ff7f880001333e993%2C601a236ff7f880001333e993%2C6011f3c1fa2b92009a1c0e2a",
                     "includeNullApptTypes=true",
                     "limit=100",
                     "page=1",
-                    "patientForm=603fd7026345ba0013a476ef",
+                    "patientForm=605b942348503f001279a0e6",
                     "populate=true",
-                    "provider=601a24ac98d5e900120d2582%2C6011f3c2fa2b92009a1c0e59%2C6011f3c2fa2b92009a1c0e69%2C6011f3c2fa2b92009a1c0e6d",
+                    "provider=601a24ac98d5e900120d2582%2C6011f3c2fa2b92009a1c0e59%2C6011f3c2fa2b92009a1c0e6b%2C6011f3c2fa2b92009a1c0e6d",
                     "sort=date",
                     "sortBy=asc",
                     "status=available",
                 ].join("&"),
                 method: "GET",
                 headers: {
+                    "Content-Type": "application/json;charset=UTF-8",
                     "x-access-token": accessToken,
                 },
             });

--- a/test/EastBostonNHCTest.js
+++ b/test/EastBostonNHCTest.js
@@ -36,7 +36,7 @@ const fakeAvailabilityResponse = {
         },
         {
             facility: {
-                _id: "6011f3c1fa2b92009a1c0e28",
+                _id: "6011f3c1fa2b92009a1c0e26",
                 name: "COVID19 VACCINE REVERE",
                 postcode: "02151",
             },
@@ -81,7 +81,7 @@ describe("East Boston NHC Availability Scraper", function () {
                     "https://patient.lumahealth.io/survey?patientFormTemplate=601d6aec4f308f00128eb4cd&user=600f45213901d90012deb171",
                 restrictions:
                     "Open to eligible residents of the following neighborhoods: Chelsea (02150), East Boston (02128), Everett (02149), Revere (02151), South End (02118), Winthrop (02152)",
-                street: "10 Garofalo St",
+                street: "1290 N Shore Road",
                 city: "Revere",
                 zip: "02151",
             },


### PR DESCRIPTION
We're seeing some errors when the East Boston scraper runs, sometimes: https://macovidvaccines.slack.com/archives/C01NADTMYQM/p1616611777026100

I logged the results so we can diagnose it next time, and added a ContentType header to tell the server that we expect JSON back.

I also went through the signup flow myself and noticed some differences in query params, so I updated them. (For example, the location in Revere changed).