### PR TITLE
Write scraper outputs to Fauna

### DIFF
--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -29,7 +29,7 @@ jobs:
         env:
           DEVELOPMENT: true
           CHROMEPATH: /usr/bin/chromium-browser
-          FAUNA_DB_DEV: ${{ secrets.FAUNA_DB_DEV }}
+          FAUNA_DB: ${{ secrets.FAUNA_DB_DEV }}
         run: |
           if [ -z "${{ secrets.FAUNA_DB_DEV }}" ]
           then

--- a/.github/workflows/prod_deploy.yaml
+++ b/.github/workflows/prod_deploy.yaml
@@ -62,7 +62,7 @@ jobs:
           WalgreensPassword=${{ secrets.WALGREENS_PASSWORD }} \
           WalgreensChallenge=${{ secrets.WALGREENS_CHALLENGE }} \
           WalgreensApiKey=${{ secrets. WALGREENS_API_KEY }} \
-          DbKeySecret=${{ secrets.FAUNA_DB_PROD }} \
+          FaunaApiKey=${{ secrets.FAUNA_DB_PROD }} \
           NodeEnv=production \
           BucketName=${{ secrets.AWSS3BUCKETNAME }} \
           RecaptchaToken=${{ secrets.RECAPTCHA_TOKEN }} \

--- a/getGeocode.js
+++ b/getGeocode.js
@@ -68,3 +68,4 @@ const getAllCoordinates = async (locations, cachedResults) => {
 };
 
 exports.getAllCoordinates = getAllCoordinates;
+exports.getGeocode = getGeocode;

--- a/lib/db-utils.js
+++ b/lib/db-utils.js
@@ -2,21 +2,35 @@ const dotenv = require("dotenv");
 dotenv.config();
 const { generateKey } = require("../data/dataDefaulter");
 const faunadb = require("faunadb"),
-    q = faunadb.query;
+    fq = faunadb.query;
+const lodash = require("lodash");
+const { getGeocode } = require("./../getGeocode");
 
-var client = new faunadb.Client({ secret: process.env.FAUNA_DB_DEV });
+DEBUG = false; // set to false to disable debugging
+function debug_log(...args) {
+    if (DEBUG) {
+        console.log(...args);
+    }
+}
+
+const client = new faunadb.Client({ secret: process.env.FAUNA_DB });
 
 /* 
     General utility methods, used just within db-utils and test file.
 */
 async function faunaQuery(query) {
     try {
+        debug_log(`trying to execute query ${JSON.stringify(query)}`);
         const res = await client.query(query);
+        debug_log(
+            `successfully executed query ${JSON.stringify(
+                query
+            )}, got res ${JSON.stringify(res)}`
+        );
         return res;
     } catch (error) {
-        // Keeping this log here for debugging purposes.
-        // console.log(`for query ${JSON.stringify(query)}, got error ${error}`);
-        // console.log(error.description);
+        console.error(`for query ${JSON.stringify(query)}, got error ${error}`);
+        console.error(error.description);
         throw error;
     }
 }
@@ -30,7 +44,7 @@ function hashCode(s) {
 }
 
 async function generateId() {
-    return faunaQuery(q.NewId());
+    return faunaQuery(fq.NewId());
 }
 
 function generateLocationId({ name, street, city, zip }) {
@@ -38,7 +52,83 @@ function generateLocationId({ name, street, city, zip }) {
     const keyString = generateKey({ name, street, city, zip });
     // FaunaDB only accepts positive ref ids, so we make it positive.
     const hash = Math.abs(hashCode(keyString));
-    return hash;
+    return hash.toString();
+}
+
+function addGeneratedIdsToLocations(locations) {
+    return locations.reduce((acc, curr) => {
+        return [
+            {
+                ...curr,
+                // FaunaDB only accepts positive ref ids, so we make it positive.
+                refId: Math.abs(
+                    // hash it
+                    hashCode(
+                        // This deterministically generates a key from the location info.
+                        generateKey({
+                            name: curr.name,
+                            street: curr.street,
+                            city: curr.city,
+                            zip: curr.zip,
+                        })
+                    )
+                ).toString(),
+            },
+            ...acc,
+        ];
+    }, []);
+}
+
+function addScraperRunIdsToLocations(locations) {
+    return locations.reduce(async (acc, curr) => {
+        return [
+            {
+                ...curr,
+                scraperRunId: await generateId(),
+            },
+            ...(await acc),
+        ];
+    }, []);
+}
+
+function addAppointmentsToLocations(locations) {
+    return locations.reduce(async (acc, loc) => {
+        if (loc.hasAvailability && loc.availability) {
+            return [
+                ...(await acc),
+                {
+                    ...loc,
+                    appointments: lodash.compact(
+                        await Promise.all(
+                            Object.entries(loc.availability).map(
+                                async ([date, dateAvailability]) => {
+                                    if (
+                                        dateAvailability.hasAvailability &&
+                                        dateAvailability.numberAvailableAppointments >
+                                            0
+                                    ) {
+                                        return {
+                                            appointmentsRefId: await generateId(),
+                                            scraperRunRefId: loc.scraperRunId,
+                                            date,
+                                            numberAvailable:
+                                                dateAvailability.numberAvailableAppointments,
+                                            signUpLink:
+                                                dateAvailability.signUpLink ||
+                                                loc.signUpLink ||
+                                                null,
+                                            extraData: loc.extraData,
+                                        };
+                                    }
+                                }
+                            )
+                        )
+                    ),
+                },
+            ];
+        }
+        return [...(await acc)];
+    }, []);
 }
 
 /*
@@ -46,25 +136,53 @@ function generateLocationId({ name, street, city, zip }) {
 */
 async function retrieveItemByRefId(collectionName, refId) {
     const result = await faunaQuery(
-        q.Get(q.Ref(q.Collection(collectionName), refId))
+        fq.Get(fq.Ref(fq.Collection(collectionName), refId))
     );
-    // console.log(
-    //     `querying ${collectionName} collection with refId ${refId} and got result ${JSON.stringify(
-    //         result
-    //     )}`
-    // );
+    debug_log(
+        `querying ${collectionName} collection with refId ${refId} and got result ${JSON.stringify(
+            result
+        )}`
+    );
+    return result;
+}
+
+async function retrieveItemsByRefIds(collectionName, refIds) {
+    const queries = refIds.map((refId) =>
+        fq.Get(fq.Ref(fq.Collection(collectionName), refId))
+    );
+    const result = await faunaQuery(queries);
+    debug_log(
+        `querying ${collectionName} collection with refIds ${refIds} and got result ${JSON.stringify(
+            result
+        )}`
+    );
     return result;
 }
 
 async function checkItemExistsByRefId(collectionName, refId) {
     const result = await faunaQuery(
-        q.Exists(q.Ref(q.Collection(collectionName), refId))
+        fq.Exists(fq.Ref(fq.Collection(collectionName), refId))
     );
     return result;
 }
 
+async function checkItemsExistByRefIds(collectionName, refIds) {
+    const queries = refIds.map((refId) =>
+        fq.Exists(fq.Ref(fq.Collection(collectionName), refId))
+    );
+    const result = await faunaQuery(queries);
+    return result;
+}
+
 async function deleteItemByRefId(collectionName, refId) {
-    await faunaQuery(q.Delete(q.Ref(q.Collection(collectionName), refId)));
+    await faunaQuery(fq.Delete(fq.Ref(fq.Collection(collectionName), refId)));
+}
+
+async function deleteItemsByRefIds(collectionName, refIds) {
+    const queries = refIds.map((refId) =>
+        fq.Delete(fq.Ref(fq.Collection(collectionName), refId))
+    );
+    await faunaQuery(queries);
 }
 
 async function writeLocationByRefId({
@@ -76,7 +194,7 @@ async function writeLocationByRefId({
     longitude,
 }) {
     await faunaQuery(
-        q.Create(q.Ref(q.Collection("locations"), refId), {
+        fq.Create(fq.Ref(fq.Collection("locations"), refId), {
             data: {
                 name,
                 address: {
@@ -92,15 +210,47 @@ async function writeLocationByRefId({
     );
 }
 
+async function writeLocationsByRefIds(locationsWithRefIds) {
+    const queries = locationsWithRefIds.map((loc) =>
+        fq.Create(fq.Ref(fq.Collection("locations"), loc.refId), {
+            data: {
+                name: loc.name,
+                address: {
+                    street: loc.street,
+                    city: loc.city,
+                    zip: loc.zip,
+                },
+                signUpLink: loc.signUpLink,
+                latitude: loc.latitude,
+                longitude: loc.longitude,
+            },
+        })
+    );
+    await faunaQuery(queries);
+}
+
 async function writeScraperRunByRefId({ refId, locationRefId, timestamp }) {
     await faunaQuery(
-        q.Create(q.Ref(q.Collection("scraperRuns"), refId), {
+        fq.Create(fq.Ref(fq.Collection("scraperRuns"), refId), {
             data: {
-                locationRef: q.Ref(q.Collection("locations"), locationRefId),
+                locationRef: fq.Ref(fq.Collection("locations"), locationRefId),
                 timestamp,
             },
         })
     );
+}
+
+async function writeScraperRunsByRefIds(locationAndScraperRunsIds, timestamp) {
+    const queries = locationAndScraperRunsIds.map((loc) =>
+        fq.Create(fq.Ref(fq.Collection("scraperRuns"), loc.scraperRunId), {
+            data: {
+                locationRef: fq.Ref(fq.Collection("locations"), loc.refId),
+                timestamp,
+            },
+        })
+    );
+    const result = await faunaQuery(queries);
+    return result;
 }
 
 async function writeAppointmentsByRefId({
@@ -112,10 +262,10 @@ async function writeAppointmentsByRefId({
     extraData,
 }) {
     await faunaQuery(
-        q.Create(q.Ref(q.Collection("appointments"), refId), {
+        fq.Create(fq.Ref(fq.Collection("appointments"), refId), {
             data: {
-                scraperRunRef: q.Ref(
-                    q.Collection("scraperRuns"),
+                scraperRunRef: fq.Ref(
+                    fq.Collection("scraperRuns"),
                     scraperRunRefId
                 ),
                 date,
@@ -127,52 +277,115 @@ async function writeAppointmentsByRefId({
     );
 }
 
+async function writeAppointmentsByRefIds(locationsWithAllData) {
+    const queries = locationsWithAllData
+        .map((loc) =>
+            loc.appointments.map((a) =>
+                fq.Create(
+                    fq.Ref(fq.Collection("appointments"), a.appointmentsRefId),
+                    {
+                        data: {
+                            scraperRunRef: fq.Ref(
+                                fq.Collection("scraperRuns"),
+                                a.scraperRunRefId
+                            ),
+                            date: a.date,
+                            numberAvailable: a.numberAvailable,
+                            signUpLink: a.signUpLink,
+                            extraData: a.extraData,
+                        },
+                    }
+                )
+            )
+        )
+        .flat();
+    debug_log("writeAppointmentsByRefIds queries", JSON.stringify(queries));
+    const result = await faunaQuery(queries);
+    return result;
+}
+
 /*
     Index-based queries. This allows us to search our indexes (scraperRunsByLocation, appointmentsByScraperRun).
 */
-async function getScaperRunsByLocation(locationRefId) {
+async function getScraperRunsByLocation(locationRefId) {
     const scraperRuns = await faunaQuery(
-        q.Map(
-            q.Paginate(
-                q.Match(
-                    q.Index("scraperRunsByLocation"),
-                    q.Ref(q.Collection("locations"), locationRefId)
+        fq.Map(
+            fq.Paginate(
+                fq.Match(
+                    fq.Index("scraperRunsByLocation"),
+                    fq.Ref(fq.Collection("locations"), locationRefId)
                 )
             ),
-            q.Lambda((x) => q.Get(x))
+            fq.Lambda((x) => fq.Get(x))
         )
     );
-    // console.log(
-    //     `for locationRefId ${locationRefId} got response ${JSON.stringify(
-    //         scraperRuns
-    //     )}`
-    // );
+    debug_log(
+        `for locationRefId ${locationRefId} got response ${JSON.stringify(
+            scraperRuns
+        )}`
+    );
+    return scraperRuns;
+}
+
+async function getScraperRunsByLocations(locations) {
+    const queries = locations.map((loc) =>
+        fq.Map(
+            fq.Paginate(
+                fq.Match(
+                    fq.Index("scraperRunsByLocation"),
+                    fq.Ref(fq.Collection("locations"), loc.refId)
+                )
+            ),
+            fq.Lambda((x) => fq.Get(x))
+        )
+    );
+    const scraperRuns = await faunaQuery(queries);
     return scraperRuns;
 }
 
 async function getAppointmentsByScraperRun(scraperRunRefId) {
     const appointments = await faunaQuery(
-        q.Map(
-            q.Paginate(
-                q.Match(
-                    q.Index("appointmentsByScraperRun"),
-                    q.Ref(q.Collection("scraperRuns"), scraperRunRefId)
+        fq.Map(
+            fq.Paginate(
+                fq.Match(
+                    fq.Index("appointmentsByScraperRun"),
+                    fq.Ref(fq.Collection("scraperRuns"), scraperRunRefId)
                 )
             ),
-            q.Lambda((x) => q.Get(x))
+            fq.Lambda((x) => fq.Get(x))
         )
     );
-    // console.log(
-    //     `for scraperRunRefId ${scraperRunRefId} got response ${JSON.stringify(
-    //         appointments
-    //     )}`
-    // );
+    debug_log(
+        `for scraperRunRefId ${scraperRunRefId} got response ${JSON.stringify()}`
+    );
+    return appointments;
+}
+
+async function getAppointmentsByScraperRuns(scraperRunRefIds) {
+    const queries = await scraperRunRefIds.map((scraperRunRefId) =>
+        fq.Map(
+            fq.Paginate(
+                fq.Match(
+                    fq.Index("appointmentsByScraperRun"),
+                    fq.Ref(fq.Collection("scraperRuns"), scraperRunRefId)
+                )
+            ),
+            fq.Lambda((x) => fq.Get(x))
+        )
+    );
+    const appointments = await faunaQuery(queries);
+
+    debug_log(
+        `for scraperRunRefIds ${scraperRunRefIds} got response ${JSON.stringify(
+            appointments
+        )}`
+    );
     return appointments;
 }
 
 /* 
     Utility that for one scraper output, writes to all the tables (locations, scraperRuns, and appointments).
-    We will call this many times from main.js.
+    We will call this many times from scraper.js.
 */
 async function writeScrapedData({
     name,
@@ -183,15 +396,15 @@ async function writeScrapedData({
     hasAvailability,
     extraData,
     timestamp,
-    latitude,
-    longitude,
     signUpLink,
 }) {
     const locationRefId = generateLocationId({ name, street, city, zip });
     const itemExists = await checkItemExistsByRefId("locations", locationRefId);
+    debug_log(`item ${locationRefId} exists: ${itemExists}`);
     if (!itemExists) {
+        const locationData = await getGeocode(name, street, zip);
         await writeLocationByRefId({
-            refId: locationRefId,
+            refId: locationRefId.toString(),
             name,
             address: {
                 street,
@@ -199,8 +412,8 @@ async function writeScrapedData({
                 zip,
             },
             signUpLink,
-            latitude,
-            longitude,
+            latitude: locationData?.results[0].geometry.location.lat,
+            longitude: locationData?.results[0].geometry.location.lng,
         });
     }
 
@@ -212,24 +425,63 @@ async function writeScrapedData({
     });
 
     if (hasAvailability && availability) {
-        Object.entries(availability).map(async ([date, dateAvailability]) => {
-            if (
-                dateAvailability.hasAvailability &&
-                dateAvailability.numberAvailableAppointments > 0
-            ) {
-                const appointmentsRefId = await generateId();
-                await writeAppointmentsByRefId({
-                    refId: appointmentsRefId,
-                    scraperRunRefId,
-                    date,
-                    numberAvailable:
-                        dateAvailability.numberAvailableAppointments,
-                    signUpLink: dateAvailability.signUpLink || signUpLink,
-                    extraData,
-                });
-            }
-        });
+        await Promise.all(
+            Object.entries(availability).map(
+                async ([date, dateAvailability]) => {
+                    if (
+                        dateAvailability.hasAvailability &&
+                        dateAvailability.numberAvailableAppointments > 0
+                    ) {
+                        const appointmentsRefId = await generateId();
+                        await writeAppointmentsByRefId({
+                            refId: appointmentsRefId,
+                            scraperRunRefId,
+                            date,
+                            numberAvailable:
+                                dateAvailability.numberAvailableAppointments,
+                            signUpLink:
+                                dateAvailability.signUpLink || signUpLink,
+                            extraData,
+                        });
+                    }
+                }
+            )
+        );
     }
+}
+
+/* 
+    Utility that for a batch of scrapers' output, writes to all the tables (locations, scraperRuns, and appointments).
+    This, and the batch functions called from here, are not currently called in our code (tests only).
+    But we may want to batch in the future, so leaving this here for now. 
+*/
+async function writeScrapedDataBatch(locations, timestamp) {
+    // Generate Location RefIds
+    const locationsWithRefIds = await addGeneratedIdsToLocations(locations);
+    // Add Location documents for those that don't exist
+    const itemsExistBools = await checkItemsExistByRefIds(
+        "locations",
+        locationsWithRefIds.map((loc) => loc.refId)
+    );
+    const nonExistentLocations = locationsWithRefIds.filter((_refId, idx) => {
+        return !itemsExistBools[idx];
+    });
+    if (locationsWithRefIds.length) {
+        await writeLocationsByRefIds(nonExistentLocations);
+    }
+    // Generate scraperRuns RefIds
+    const locationsWithScraperRunIds = await addScraperRunIdsToLocations(
+        locationsWithRefIds
+    );
+    // Write scraperRuns
+    await writeScraperRunsByRefIds(locationsWithScraperRunIds, timestamp);
+
+    // Generate appointment RefIds and filter on availability
+    const locationsWithAllData = await addAppointmentsToLocations(
+        locationsWithScraperRunIds
+    );
+    debug_log("locationsWithAllData", locationsWithAllData);
+    writeAppointmentsByRefIds(locationsWithAllData);
 }
 
 /* 
@@ -239,15 +491,25 @@ async function writeScrapedData({
 async function getAppointmentsForAllLocations() {}
 
 module.exports = {
+    addGeneratedIdsToLocations,
     checkItemExistsByRefId,
+    checkItemsExistByRefIds,
     getAppointmentsForAllLocations,
     getAppointmentsByScraperRun,
+    getAppointmentsByScraperRuns,
     deleteItemByRefId,
+    deleteItemsByRefIds,
     generateLocationId,
-    getScaperRunsByLocation,
+    getScraperRunsByLocation,
+    getScraperRunsByLocations,
     retrieveItemByRefId,
+    retrieveItemsByRefIds,
     writeAppointmentsByRefId,
+    writeAppointmentsByRefIds,
     writeLocationByRefId,
+    writeLocationsByRefIds,
     writeScrapedData,
+    writeScrapedDataBatch,
     writeScraperRunByRefId,
+    writeScraperRunsByRefIds,
 };

--- a/lib/db-utils.js
+++ b/lib/db-utils.js
@@ -192,6 +192,8 @@ async function writeLocationByRefId({
     signUpLink,
     latitude,
     longitude,
+    extraData,
+    restrictions,
     massVax,
 }) {
     await faunaQuery(
@@ -206,6 +208,8 @@ async function writeLocationByRefId({
                 signUpLink,
                 latitude,
                 longitude,
+                extraData,
+                restrictions,
                 massVax,
             },
         })
@@ -267,7 +271,6 @@ async function writeAppointmentsByRefId({
     date,
     numberAvailable,
     signUpLink,
-    extraData,
 }) {
     await faunaQuery(
         fq.Create(fq.Ref(fq.Collection("appointments"), refId), {
@@ -279,7 +282,6 @@ async function writeAppointmentsByRefId({
                 date,
                 numberAvailable,
                 signUpLink,
-                extraData,
             },
         })
     );
@@ -405,6 +407,7 @@ async function writeScrapedData({
     extraData,
     timestamp,
     signUpLink,
+    restrictions,
     massVax,
     siteTimestamp,
 }) {
@@ -424,6 +427,8 @@ async function writeScrapedData({
             signUpLink,
             latitude: locationData?.results[0].geometry.location.lat,
             longitude: locationData?.results[0].geometry.location.lng,
+            extraData,
+            restrictions,
             massVax,
         });
     }
@@ -453,7 +458,6 @@ async function writeScrapedData({
                                 dateAvailability.numberAvailableAppointments,
                             signUpLink:
                                 dateAvailability.signUpLink || signUpLink,
-                            extraData,
                         });
                     }
                 }

--- a/lib/db-utils.js
+++ b/lib/db-utils.js
@@ -192,6 +192,7 @@ async function writeLocationByRefId({
     signUpLink,
     latitude,
     longitude,
+    massVax,
 }) {
     await faunaQuery(
         fq.Create(fq.Ref(fq.Collection("locations"), refId), {
@@ -205,6 +206,7 @@ async function writeLocationByRefId({
                 signUpLink,
                 latitude,
                 longitude,
+                massVax,
             },
         })
     );
@@ -229,12 +231,18 @@ async function writeLocationsByRefIds(locationsWithRefIds) {
     await faunaQuery(queries);
 }
 
-async function writeScraperRunByRefId({ refId, locationRefId, timestamp }) {
+async function writeScraperRunByRefId({
+    refId,
+    locationRefId,
+    timestamp,
+    siteTimestamp,
+}) {
     await faunaQuery(
         fq.Create(fq.Ref(fq.Collection("scraperRuns"), refId), {
             data: {
                 locationRef: fq.Ref(fq.Collection("locations"), locationRefId),
                 timestamp,
+                siteTimestamp,
             },
         })
     );
@@ -397,6 +405,8 @@ async function writeScrapedData({
     extraData,
     timestamp,
     signUpLink,
+    massVax,
+    siteTimestamp,
 }) {
     const locationRefId = generateLocationId({ name, street, city, zip });
     const itemExists = await checkItemExistsByRefId("locations", locationRefId);
@@ -414,6 +424,7 @@ async function writeScrapedData({
             signUpLink,
             latitude: locationData?.results[0].geometry.location.lat,
             longitude: locationData?.results[0].geometry.location.lng,
+            massVax,
         });
     }
 
@@ -422,6 +433,7 @@ async function writeScrapedData({
         refId: scraperRunRefId,
         locationRefId,
         timestamp,
+        siteTimestamp,
     });
 
     if (hasAvailability && availability) {

--- a/lib/db-utils.js
+++ b/lib/db-utils.js
@@ -446,8 +446,9 @@ async function writeScrapedData({
             Object.entries(availability).map(
                 async ([date, dateAvailability]) => {
                     if (
-                        dateAvailability.hasAvailability &&
-                        dateAvailability.numberAvailableAppointments > 0
+                        dateAvailability === true ||
+                        (dateAvailability.hasAvailability &&
+                            dateAvailability.numberAvailableAppointments > 0)
                     ) {
                         const appointmentsRefId = await generateId();
                         await writeAppointmentsByRefId({
@@ -455,7 +456,8 @@ async function writeScrapedData({
                             scraperRunRefId,
                             date,
                             numberAvailable:
-                                dateAvailability.numberAvailableAppointments,
+                                dateAvailability.numberAvailableAppointments ||
+                                null,
                             signUpLink:
                                 dateAvailability.signUpLink || signUpLink,
                         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "axios-retry": "^3.1.9",
                 "bestzip": "^2.1.7",
                 "chrome-aws-lambda": "^8.0.0",
+                "deep-equal-in-any-order": "^1.0.28",
                 "dotenv": "^8.2.0",
                 "faunadb": "^4.1.1",
                 "jsdom": "^16.4.0",
@@ -986,6 +987,15 @@
             },
             "engines": {
                 "node": ">=0.12"
+            }
+        },
+        "node_modules/deep-equal-in-any-order": {
+            "version": "1.0.28",
+            "resolved": "https://registry.npmjs.org/deep-equal-in-any-order/-/deep-equal-in-any-order-1.0.28.tgz",
+            "integrity": "sha512-qq3jffpGmAG9kGpZGKusjRwoGxmFgIqNW076HQmV9rNdrFsgTcpuCyp6dBhzdVCWgQDkgRmvZLYAilV4u2BsfQ==",
+            "dependencies": {
+                "lodash.mapvalues": "^4.6.0",
+                "sort-any": "^1.1.21"
             }
         },
         "node_modules/deep-is": {
@@ -2149,6 +2159,11 @@
             "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
             "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
         },
+        "node_modules/lodash.mapvalues": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
+            "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw="
+        },
         "node_modules/lodash.set": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
@@ -3196,6 +3211,14 @@
             "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/sort-any": {
+            "version": "1.1.23",
+            "resolved": "https://registry.npmjs.org/sort-any/-/sort-any-1.1.23.tgz",
+            "integrity": "sha512-aY92w1RkjIyJd1l+O4btCwfAIfZm2r+zA6+cfKbKUO5D5MEZlqY27B7QyHHIsEShBsvx+Ur1Oq3v/gfR6wxD/w==",
+            "dependencies": {
+                "lodash": "^4.17.15"
             }
         },
         "node_modules/source-map": {
@@ -4683,6 +4706,15 @@
                 "type-detect": "^4.0.0"
             }
         },
+        "deep-equal-in-any-order": {
+            "version": "1.0.28",
+            "resolved": "https://registry.npmjs.org/deep-equal-in-any-order/-/deep-equal-in-any-order-1.0.28.tgz",
+            "integrity": "sha512-qq3jffpGmAG9kGpZGKusjRwoGxmFgIqNW076HQmV9rNdrFsgTcpuCyp6dBhzdVCWgQDkgRmvZLYAilV4u2BsfQ==",
+            "requires": {
+                "lodash.mapvalues": "^4.6.0",
+                "sort-any": "^1.1.21"
+            }
+        },
         "deep-is": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -5522,6 +5554,11 @@
             "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
             "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
         },
+        "lodash.mapvalues": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
+            "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw="
+        },
         "lodash.set": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
@@ -6303,6 +6340,14 @@
                     "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
                     "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
                 }
+            }
+        },
+        "sort-any": {
+            "version": "1.1.23",
+            "resolved": "https://registry.npmjs.org/sort-any/-/sort-any-1.1.23.tgz",
+            "integrity": "sha512-aY92w1RkjIyJd1l+O4btCwfAIfZm2r+zA6+cfKbKUO5D5MEZlqY27B7QyHHIsEShBsvx+Ur1Oq3v/gfR6wxD/w==",
+            "requires": {
+                "lodash": "^4.17.15"
             }
         },
         "source-map": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
         "axios-retry": "^3.1.9",
         "bestzip": "^2.1.7",
         "chrome-aws-lambda": "^8.0.0",
+        "deep-equal-in-any-order": "^1.0.28",
         "dotenv": "^8.2.0",
         "faunadb": "^4.1.1",
         "jsdom": "^16.4.0",

--- a/scraper_common.js
+++ b/scraper_common.js
@@ -99,8 +99,11 @@ async function execute(usePuppeteer, scrapers) {
                             extraData: res.extraData,
                             timestamp: moment().utc().format(),
                             signUpLink: res.signUpLink,
+                            restrictions: res.restrictions,
                             massVax: res.massVax,
-                            siteTimestamp: res.siteTimestamp,
+                            siteTimestamp: res.siteTimestamp
+                                ? JSON.parse(JSON.stringify(res.siteTimestamp))
+                                : null,
                         });
                     })
                 );

--- a/scraper_common.js
+++ b/scraper_common.js
@@ -86,7 +86,7 @@ async function execute(usePuppeteer, scrapers) {
                 returnValueArray = [returnValue];
             }
             // Write the data to FaunaDB.
-            if (WRITE_TO_FAUNA) {
+            if (WRITE_TO_FAUNA && process.env.FAUNA_DB) {
                 try {
                     await Promise.all(
                         returnValueArray.map(async (res) => {

--- a/scraper_common.js
+++ b/scraper_common.js
@@ -68,7 +68,6 @@ async function execute(usePuppeteer, scrapers) {
                     const numberAppointments = getTotalNumberOfAppointments(
                         result
                     );
-                    // TODO - call FaunaDB util method here!
                     await logScraperRun(
                         scraper.name,
                         isSuccess,
@@ -97,7 +96,11 @@ async function execute(usePuppeteer, scrapers) {
                             zip: res.zip,
                             availability: res.availability,
                             hasAvailability: res.availability,
+                            extraData: res.extraData,
                             timestamp: moment().utc().format(),
+                            signUpLink: res.signUpLink,
+                            massVax: res.massVax,
+                            siteTimestamp: res.siteTimestamp,
                         });
                     })
                 );

--- a/scraper_common.js
+++ b/scraper_common.js
@@ -87,26 +87,32 @@ async function execute(usePuppeteer, scrapers) {
             }
             // Write the data to FaunaDB.
             if (WRITE_TO_FAUNA) {
-                await Promise.all(
-                    returnValueArray.map(async (res) => {
-                        await dbUtils.writeScrapedData({
-                            name: res.name,
-                            street: res.street,
-                            city: res.city,
-                            zip: res.zip,
-                            availability: res.availability,
-                            hasAvailability: res.availability,
-                            extraData: res.extraData,
-                            timestamp: moment().utc().format(),
-                            signUpLink: res.signUpLink,
-                            restrictions: res.restrictions,
-                            massVax: res.massVax,
-                            siteTimestamp: res.siteTimestamp
-                                ? JSON.parse(JSON.stringify(res.siteTimestamp))
-                                : null,
-                        });
-                    })
-                );
+                try {
+                    await Promise.all(
+                        returnValueArray.map(async (res) => {
+                            await dbUtils.writeScrapedData({
+                                name: res.name,
+                                street: res.street,
+                                city: res.city,
+                                zip: res.zip,
+                                availability: res.availability,
+                                hasAvailability: res.availability,
+                                extraData: res.extraData,
+                                timestamp: moment().utc().format(),
+                                signUpLink: res.signUpLink,
+                                restrictions: res.restrictions,
+                                massVax: res.massVax,
+                                siteTimestamp: res.siteTimestamp
+                                    ? JSON.parse(
+                                          JSON.stringify(res.siteTimestamp)
+                                      )
+                                    : null,
+                            });
+                        })
+                    );
+                } catch (e) {
+                    console.error("Failed to write to Fauna, got error:", e);
+                }
             }
         }
         if (usePuppeteer) {

--- a/template.yaml
+++ b/template.yaml
@@ -20,7 +20,7 @@ Parameters:
     Type: String
   WalgreensApiKey:
     Type: String
-  DbKeySecret:
+  FaunaApiKey:
     Type: String
   NodeEnv:
     Type: String
@@ -67,7 +67,7 @@ Resources:
           WALGREENS_PASSWORD: !Ref WalgreensPassword
           WALGREENS_CHALLENGE: !Ref WalgreensChallenge
           WALGREENS_API_KEY: !Ref WalgreensApiKey
-          DB_KEY_SECRET: !Ref DbKeySecret
+          FAUNA_DB: !Ref FaunaApiKey
           NODE_ENV: !Ref NodeEnv
           AWSS3BUCKETNAME: !Ref BucketName
           RECAPTCHATOKEN: !Ref RecaptchaToken
@@ -95,7 +95,7 @@ Resources:
       Environment:
         Variables:
           GOOGLE_API_KEY: !Ref GoogleApiKey
-          DB_KEY_SECRET: !Ref DbKeySecret
+          FAUNA_DB: !Ref FaunaApiKey
           NODE_ENV: !Ref NodeEnv
           AWSS3BUCKETNAME: !Ref BucketName
           SLACKWEBHOOKBOTCHANNEL: !Ref SlackWebhook

--- a/test/db-utils-test.js
+++ b/test/db-utils-test.js
@@ -1,24 +1,25 @@
 const chai = require("chai");
 chai.use(require("chai-as-promised"));
 chai.use(require("chai-shallow-deep-equal"));
+chai.use(require("deep-equal-in-any-order"));
 const expect = chai.expect;
 const lodash = require("lodash");
 
 describe("FaunaDB Utils", function () {
     const dbUtils = require("../lib/db-utils");
-    it("can create, retrieve, and delete docs from Locations collection", async () => {
+    it("can create, retrieve, and delete docs from Locations collection (once doc at a time)", async () => {
         const randomName = Math.random().toString(36).substring(7);
         const collectionName = "locations";
-        const data = {
+        const location = {
             name: `RandomName-${randomName}`,
             address: { street: "1 Main St", city: "Newton", zip: "02458" },
             signUpLink: "www.google.com",
         };
-        const generatedId = await dbUtils.generateLocationId({
-            name: data.name,
-            steet: data.address.street,
-            city: data.address.city,
-            zip: data.address.zip,
+        const generatedId = dbUtils.generateLocationId({
+            name: location.name,
+            steet: location.address.street,
+            city: location.address.city,
+            zip: location.address.zip,
         });
 
         await expect(
@@ -31,7 +32,7 @@ describe("FaunaDB Utils", function () {
 
         await dbUtils.writeLocationByRefId({
             refId: generatedId,
-            ...data,
+            ...location,
         });
 
         await expect(
@@ -58,13 +59,88 @@ describe("FaunaDB Utils", function () {
                     id: generatedId,
                 },
             },
-            data,
+            data: location,
         });
 
         await dbUtils.deleteItemByRefId(collectionName, generatedId);
         await expect(
             dbUtils.retrieveItemByRefId(collectionName, generatedId)
         ).to.eventually.be.rejectedWith("instance not found");
+    }).timeout(3000);
+
+    it("can create, retrieve, and delete docs from Locations collection (in batches)", async () => {
+        const collectionName = "locations";
+        const locations = [
+            {
+                name: `RandomName-${Math.random().toString(36).substring(7)}`,
+                street: "1 Main St",
+                city: "Newton",
+                zip: "02458",
+                signUpLink: "www.google.com",
+            },
+            {
+                name: `RandomName-${Math.random().toString(36).substring(7)}`,
+                street: "2 Main St",
+                city: "Newton",
+                zip: "02458",
+                signUpLink: "www.google.com",
+            },
+        ];
+        const locationsWithRefIds = dbUtils.addGeneratedIdsToLocations(
+            locations
+        );
+        const locationRefIds = locationsWithRefIds.map((loc) => loc.refId);
+
+        await expect(
+            dbUtils.retrieveItemsByRefIds(collectionName, locationRefIds)
+        ).to.eventually.be.rejectedWith("instance not found");
+
+        await expect(
+            dbUtils.checkItemsExistByRefIds(collectionName, locationRefIds)
+        ).to.eventually.deep.equal([false, false]);
+
+        await dbUtils.writeLocationsByRefIds(locationsWithRefIds);
+
+        await expect(
+            dbUtils.checkItemsExistByRefIds(collectionName, locationRefIds)
+        ).to.eventually.deep.equal([true, true]);
+
+        const retrieveResult = await dbUtils.retrieveItemsByRefIds(
+            collectionName,
+            locationRefIds
+        );
+        const filteredResults = retrieveResult.map(
+            (entry) => lodash.omit(entry, ["ts", "ref"]) // remove the timestamp and reference, too complicated to check against
+        );
+        expect(filteredResults).to.have.deep.members([
+            {
+                data: {
+                    name: locations[0].name,
+                    address: {
+                        street: locations[0].street,
+                        city: locations[0].city,
+                        zip: locations[0].zip,
+                    },
+                    signUpLink: locations[0].signUpLink,
+                },
+            },
+            {
+                data: {
+                    name: locations[1].name,
+                    address: {
+                        street: locations[1].street,
+                        city: locations[1].city,
+                        zip: locations[1].zip,
+                    },
+                    signUpLink: locations[1].signUpLink,
+                },
+            },
+        ]);
+
+        await dbUtils.deleteItemsByRefIds(collectionName, locationRefIds);
+        await expect(
+            dbUtils.checkItemsExistByRefIds(collectionName, locationRefIds)
+        ).to.eventually.deep.equal([false, false]);
     }).timeout(3000);
 
     it("given one scraper's output, can create, retrieve, and delete docs from Locations, ScraperRuns, and Appointments collections", async () => {
@@ -95,8 +171,6 @@ describe("FaunaDB Utils", function () {
                 "Clinic Hours": "10:00 am - 03:00 pm",
             },
             timestamp: "2021-03-16T13:15:27.318Z",
-            latitude: 41.6909399,
-            longitude: -70.3373802,
             signUpLink: "fake-signup-link",
         };
 
@@ -139,13 +213,11 @@ describe("FaunaDB Utils", function () {
                     city: scraperOutput.city,
                     zip: scraperOutput.zip,
                 },
-                latitude: scraperOutput.latitude,
-                longitude: scraperOutput.longitude,
                 signUpLink: scraperOutput.signUpLink,
             },
         });
         // assert that the scraper run is there (check index)
-        const retrieveScraperRunResult = await dbUtils.getScaperRunsByLocation(
+        const retrieveScraperRunResult = await dbUtils.getScraperRunsByLocation(
             locationId
         );
         expect(retrieveScraperRunResult).to.be.shallowDeepEqual({
@@ -230,7 +302,252 @@ describe("FaunaDB Utils", function () {
         appointmentRefIds.map(async (id) => {
             await dbUtils.deleteItemByRefId("appointments", id);
         });
-    }).timeout(4000);
+    }).timeout(5000);
+
+    it("given a batch of scrapers outputs, can create, retrieve, and delete docs from Locations, ScraperRuns, and Appointments collections", async () => {
+        const timestamp = "2021-04-07T00:00:00.00Z";
+        const locations = [
+            {
+                name: `RandomName-${Math.random().toString(36).substring(7)}`,
+                street: "2240 Iyannough Road",
+                city: "West Barnstable",
+                zip: "02668",
+                availability: {
+                    "03/16/2021": {
+                        hasAvailability: true,
+                        numberAvailableAppointments: 2,
+                        signUpLink: "fake-signup-link-2",
+                    },
+                    "03/17/2021": {
+                        hasAvailability: true,
+                        numberAvailableAppointments: 1,
+                        signUpLink: null,
+                    },
+                },
+                hasAvailability: true,
+                extraData: {
+                    "Vaccinations offered": "Pfizer-BioNTech COVID-19 Vaccine",
+                    "Age groups served": "Adults",
+                    "Services offered": "Vaccination",
+                    "Additional Information": "Pfizer vaccine",
+                    "Clinic Hours": "10:00 am - 03:00 pm",
+                },
+                timestamp: "2021-03-16T13:15:27.318Z",
+                latitude: 41.6909399,
+                longitude: -70.3373802,
+                signUpLink: "fake-signup-link",
+            },
+            {
+                name: `RandomName-${Math.random().toString(36).substring(7)}`,
+                street: "409 W Broadway",
+                city: "South Boston",
+                zip: "02127",
+                availability: {
+                    "03/30/2021": {
+                        hasAvailability: true,
+                        numberAvailableAppointments: 30,
+                        signUpLink: "fake-signup-link-3",
+                    },
+                },
+                hasAvailability: true,
+                timestamp: "2021-03-16T16:16:16.318Z",
+                latitude: 100,
+                longitude: -100,
+                signUpLink: "fake-signup-link-3",
+            },
+            {
+                name: `RandomName-${Math.random().toString(36).substring(7)}`,
+                street: "280 Main Street",
+                city: "Rutland",
+                zip: "01543",
+                availability: {},
+                hasAvailability: false,
+                timestamp: "2021-03-16T21:21:21.318Z",
+                latitude: 50,
+                longitude: -50,
+                signUpLink: "fake-signup-link-4",
+            },
+        ];
+        // Write the appopriate location (if it's not already there), scaperRun, and appointment(s)
+        await dbUtils.writeScrapedDataBatch(locations, timestamp);
+
+        // sleep while the DB writing happens...
+        await new Promise((r) => setTimeout(r, 1000));
+
+        const locationsWithRefIds = dbUtils.addGeneratedIdsToLocations(
+            locations
+        );
+        const locationRefIds = locationsWithRefIds.map((loc) => loc.refId);
+        const retrieveLocationsResult = await dbUtils.retrieveItemsByRefIds(
+            "locations",
+            locationRefIds
+        );
+        const filteredResults = retrieveLocationsResult.map(
+            (entry) => lodash.omit(entry, ["ts", "ref"]) // remove the timestamp and reference, too complicated to check against
+        );
+        expect(filteredResults).to.deep.equalInAnyOrder([
+            {
+                data: {
+                    name: locations[0].name,
+                    address: {
+                        street: locations[0].street,
+                        city: locations[0].city,
+                        zip: locations[0].zip,
+                    },
+                    signUpLink: locations[0].signUpLink,
+                    latitude: locations[0].latitude,
+                    longitude: locations[0].longitude,
+                },
+            },
+            {
+                data: {
+                    name: locations[1].name,
+                    address: {
+                        street: locations[1].street,
+                        city: locations[1].city,
+                        zip: locations[1].zip,
+                    },
+                    signUpLink: locations[1].signUpLink,
+                    latitude: locations[1].latitude,
+                    longitude: locations[1].longitude,
+                },
+            },
+            {
+                data: {
+                    name: locations[2].name,
+                    address: {
+                        street: locations[2].street,
+                        city: locations[2].city,
+                        zip: locations[2].zip,
+                    },
+                    signUpLink: locations[2].signUpLink,
+                    latitude: locations[2].latitude,
+                    longitude: locations[2].longitude,
+                },
+            },
+        ]);
+        // assert that the scraper run is there (check index)
+        const retrieveScraperRunsResult = await dbUtils.getScraperRunsByLocations(
+            locationsWithRefIds
+        );
+
+        const scraperRunRefs = retrieveScraperRunsResult.map(
+            (res) => res.data[0].ref.id
+        );
+        const filteredResults2 = retrieveScraperRunsResult.map((entry) => {
+            return lodash.set(
+                entry,
+                "data",
+                entry.data.map((subEntry) =>
+                    lodash.omit(subEntry, ["data.locationRef", "ref", "ts"])
+                )
+            );
+        });
+
+        expect(filteredResults2).to.deep.equalInAnyOrder([
+            {
+                data: [
+                    {
+                        data: {
+                            timestamp,
+                        },
+                    },
+                ],
+            },
+            {
+                data: [
+                    {
+                        data: {
+                            timestamp,
+                        },
+                    },
+                ],
+            },
+            {
+                data: [
+                    {
+                        data: {
+                            timestamp,
+                        },
+                    },
+                ],
+            },
+        ]);
+
+        const retrieveAppointmentsResult = await dbUtils.getAppointmentsByScraperRuns(
+            scraperRunRefs
+        );
+
+        const appointmentRefIds = retrieveAppointmentsResult
+            .map((entry) => entry.data.map((subEntry) => subEntry.ref.id))
+            .flat();
+
+        const filteredResults3 = retrieveAppointmentsResult.map((entry) => {
+            return lodash.set(
+                entry,
+                "data",
+                entry.data.map((subEntry) =>
+                    lodash.omit(subEntry, ["data.scraperRunRef", "ref", "ts"])
+                )
+            );
+        });
+
+        expect(filteredResults3).to.deep.equalInAnyOrder([
+            {
+                data: [
+                    {
+                        data: {
+                            date: "03/30/2021",
+                            numberAvailable: 30,
+                            signUpLink: "fake-signup-link-3",
+                        },
+                    },
+                ],
+            },
+            {
+                data: [
+                    {
+                        data: {
+                            date: "03/16/2021",
+                            numberAvailable: 2,
+                            signUpLink: "fake-signup-link-2",
+                            extraData: {
+                                "Vaccinations offered":
+                                    "Pfizer-BioNTech COVID-19 Vaccine",
+                                "Age groups served": "Adults",
+                                "Services offered": "Vaccination",
+                                "Additional Information": "Pfizer vaccine",
+                                "Clinic Hours": "10:00 am - 03:00 pm",
+                            },
+                        },
+                    },
+                    {
+                        data: {
+                            date: "03/17/2021",
+                            numberAvailable: 1,
+                            signUpLink: "fake-signup-link",
+                            extraData: {
+                                "Vaccinations offered":
+                                    "Pfizer-BioNTech COVID-19 Vaccine",
+                                "Age groups served": "Adults",
+                                "Services offered": "Vaccination",
+                                "Additional Information": "Pfizer vaccine",
+                                "Clinic Hours": "10:00 am - 03:00 pm",
+                            },
+                        },
+                    },
+                ],
+            },
+            {
+                data: [],
+            },
+        ]);
+
+        // clean up - delete it all
+        await dbUtils.deleteItemsByRefIds("locations", locationRefIds);
+        await dbUtils.deleteItemsByRefIds("scraperRuns", scraperRunRefs);
+        await dbUtils.deleteItemsByRefIds("appointments", appointmentRefIds);
+    }).timeout(5000);
 
     it("can get the availability for all locations' most recent scraper runs", async () => {
         await dbUtils.getAppointmentsForAllLocations();

--- a/test/db-utils-test.js
+++ b/test/db-utils-test.js
@@ -161,6 +161,12 @@ describe("FaunaDB Utils", function () {
                     numberAvailableAppointments: 1,
                     signUpLink: null,
                 },
+                "03/18/2021": true,
+                "03/19/2021": false,
+                "03/20/2021": {
+                    hasAvailability: true,
+                    numberAvailableAppointments: 0,
+                },
             },
             hasAvailability: true,
             extraData: {
@@ -276,6 +282,10 @@ describe("FaunaDB Utils", function () {
             {
                 date: "03/17/2021",
                 numberAvailable: 1,
+                signUpLink: "fake-signup-link",
+            },
+            {
+                date: "03/18/2021",
                 signUpLink: "fake-signup-link",
             },
         ]);

--- a/test/db-utils-test.js
+++ b/test/db-utils-test.js
@@ -214,6 +214,7 @@ describe("FaunaDB Utils", function () {
                     zip: scraperOutput.zip,
                 },
                 signUpLink: scraperOutput.signUpLink,
+                extraData: scraperOutput.extraData,
             },
         });
         // assert that the scraper run is there (check index)
@@ -271,25 +272,11 @@ describe("FaunaDB Utils", function () {
                 date: "03/16/2021",
                 numberAvailable: 2,
                 signUpLink: "fake-signup-link-2",
-                extraData: {
-                    "Vaccinations offered": "Pfizer-BioNTech COVID-19 Vaccine",
-                    "Age groups served": "Adults",
-                    "Services offered": "Vaccination",
-                    "Additional Information": "Pfizer vaccine",
-                    "Clinic Hours": "10:00 am - 03:00 pm",
-                },
             },
             {
                 date: "03/17/2021",
                 numberAvailable: 1,
                 signUpLink: "fake-signup-link",
-                extraData: {
-                    "Vaccinations offered": "Pfizer-BioNTech COVID-19 Vaccine",
-                    "Age groups served": "Adults",
-                    "Services offered": "Vaccination",
-                    "Additional Information": "Pfizer vaccine",
-                    "Clinic Hours": "10:00 am - 03:00 pm",
-                },
             },
         ]);
         const appointmentRefIds = retrieveAppointmentsResult.data.map(


### PR DESCRIPTION
This PR adds logic to write each scraper's output from `scraper.js` and `scrapers_no_browser` but behind a boolean set to False. I'll turn it on after this is merged so it's a smaller PR to revert if needed.
It also includes some minor fixes, such as making a fix to the async/await logic for writing appointments.

I also added logic to read/write all the data in batches. This is actually the majority of the diff in this code. It's in preparation for when we will read the data from the tables, in batches. 