### PR TITLE
replace pull_request with pull_request_target

### DIFF
--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -1,6 +1,6 @@
 name: node.js
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - master
 jobs:

--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -1,6 +1,6 @@
 name: node.js
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - master
 jobs:

--- a/scraper.js
+++ b/scraper.js
@@ -125,7 +125,7 @@ async function execute() {
         const webData = JSON.stringify(responseJson);
 
         if (process.env.DEVELOPMENT) {
-            //console.log("The following data would be published:");
+            console.log("The following data would be published:");
             //console.dir(responseJson, { depth: null });
             file.write("out.json", webData);
             return responseJson;


### PR DESCRIPTION
To pass Github secrets to forks (so that tests can run with credentials for Fauna), I updated our Github workflow to run on `pull_request_target` instead of `pull_request`. 
See context: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/

After merging, I will see if secrets get passed successfully from a test branch.