### PR TITLE
Update Github Workflows

### DIFF
--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -1,11 +1,11 @@
-name: Test workflow
+name: Workflow 1 - Test
 on:
   pull_request:
     branches:
       - master
   push:
-    branches: 
-      - tj/runTestsOnPRMerge
+    branches:
+      - tj/runTestsOnPRMerge # todo - change to master
 jobs:
   build:
     runs-on: ubuntu-18.04
@@ -30,7 +30,7 @@ jobs:
           envkey_FAUNA_DB_DEV: ${{ secrets.FAUNA_DB_DEV }}
       - run: npm ci
       # todo: if FAUNA_DB_DEV isn't set
-        # -  don't run fauna tests.
+      # -  don't run fauna tests.
       - name: Run test suite
         env:
           DEVELOPMENT: true
@@ -38,3 +38,11 @@ jobs:
         run: npm test
       - run: npx prettier --check ./
       - run: npm run verifyLockfile
+      - name: Trigger next workflow (if pushing to master)
+        if: success() # also check that this is a push to master
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.GH_ACTION_TOKEN }}
+          repository: ${{ github.repository }}
+          event-type: trigger-workflow-2
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -5,7 +5,7 @@ on:
       - master
   push:
     branches: 
-      - master
+      - tj/runTestsOnPRMerge
 jobs:
   build:
     runs-on: ubuntu-18.04

--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -39,7 +39,7 @@ jobs:
       - run: npx prettier --check ./
       - run: npm run verifyLockfile
       - name: Trigger next workflow (if pushing to master)
-        if: success() # also check that this is a push to master
+        if: always() # also check that this is a push to master
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.GH_ACTION_TOKEN }}

--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -1,7 +1,10 @@
-name: node.js
+name: Test workflow
 on:
   pull_request:
     branches:
+      - master
+  push:
+    branches: 
       - master
 jobs:
   build:
@@ -26,6 +29,8 @@ jobs:
         with:
           envkey_FAUNA_DB_DEV: ${{ secrets.FAUNA_DB_DEV }}
       - run: npm ci
+      # todo: if FAUNA_DB_DEV isn't set
+        # -  don't run fauna tests.
       - name: Run test suite
         env:
           DEVELOPMENT: true

--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -5,7 +5,7 @@ on:
       - master
   push:
     branches:
-      - tj/runTestsOnPRMerge # todo - change to master
+      - master
 jobs:
   build:
     runs-on: ubuntu-18.04
@@ -29,8 +29,7 @@ jobs:
         with:
           envkey_FAUNA_DB_DEV: ${{ secrets.FAUNA_DB_DEV }}
       - run: npm ci
-      # todo: if FAUNA_DB_DEV isn't set
-      # -  don't run fauna tests.
+      # todo: if FAUNA_DB_DEV isn't set, don't run the fauna tests
       - name: Run test suite
         env:
           DEVELOPMENT: true
@@ -38,8 +37,8 @@ jobs:
         run: npm test
       - run: npx prettier --check ./
       - run: npm run verifyLockfile
-      - name: Trigger next workflow (if pushing to master)
-        if: always() # also check that this is a push to master
+      - name: Trigger next workflow (this only happens on the default branch, master)
+        if: success()
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.GH_ACTION_TOKEN }}

--- a/.github/workflows/prod_deploy.yaml
+++ b/.github/workflows/prod_deploy.yaml
@@ -4,7 +4,7 @@ on:
     branches: [master]
 
 jobs:
-  sam-validate-build-test-deploy:
+  sam-validate-build-test-deploy: # todo - rename this
     if: ${{ github.repository_owner == 'livgust' }}
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/prod_deploy.yaml
+++ b/.github/workflows/prod_deploy.yaml
@@ -2,12 +2,9 @@ name: Workflow 2 - SAM Validate, Build, Test, Deploy
 on:
   repository_dispatch:
     types: [trigger-workflow-2]
-  push:
-    branches:
-      - tj/runTestsOnPRMerge # todo - change to master
 
 jobs:
-  sam-validate-build-test-deploy: # todo - rename this
+  sam-validate-build-deploy:
     if: ${{ github.repository_owner == 'livgust' }}
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/prod_deploy.yaml
+++ b/.github/workflows/prod_deploy.yaml
@@ -1,7 +1,7 @@
-name: SAM Validate, Build, Test, Deploy
+name: Workflow 2 - SAM Validate, Build, Test, Deploy
 on:
-  push:
-    branches: [master]
+  repository_dispatch:
+    types: [trigger-workflow-2]
 
 jobs:
   sam-validate-build-test-deploy: # todo - rename this
@@ -11,6 +11,8 @@ jobs:
       env-name: ${{ steps.env-name.outputs.environment }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.client_payload.sha }}
       - name: Install Dependencies with Apt Get
         run: |
           sudo apt-get update

--- a/.github/workflows/prod_deploy.yaml
+++ b/.github/workflows/prod_deploy.yaml
@@ -2,6 +2,9 @@ name: Workflow 2 - SAM Validate, Build, Test, Deploy
 on:
   repository_dispatch:
     types: [trigger-workflow-2]
+  push:
+    branches:
+      - tj/runTestsOnPRMerge # todo - change to master
 
 jobs:
   sam-validate-build-test-deploy: # todo - rename this


### PR DESCRIPTION
I'm going to make a change to only run tests if the Fauna secret is present (so that forks, which don't have access to our secrets, can skip the Fauna tests). 

But this means that as a safety measure, we should really run tests after merging (in case we skipped over any in the PR stage). So I've changed our tests (in what I renamed to Workflow 1) so that they will run on PRs and merges to master. 

Then, Workflow 1 will kick off Workflow 2, using this framework: https://stevenmortimer.com/running-github-actions-sequentially/#an-example 