### PR TITLE
TrinityEMS: Comment out scraper for testing

### DIFF
--- a/site-scrapers/TrinityEMS/index.js
+++ b/site-scrapers/TrinityEMS/index.js
@@ -35,7 +35,7 @@ let notificationService = function defaultNotificationService() {
 };
 
 async function ScrapeWebsiteData(browser, pageService) {
-    const page = await pageService.getHomePage(browser);
+    //    const page = await pageService.getHomePage(browser);
 
     // Initialize results to no availability
     const results = {
@@ -43,24 +43,26 @@ async function ScrapeWebsiteData(browser, pageService) {
         hasAvailability: false,
     };
 
-    const monthCount = await getMonthCount(page);
-
-    for (const key of new Array(monthCount).keys()) {
-        // Don't advance the calendar if it's the first month
-        if (key > 0) {
-            await pageService.getNextMonthCalendar(page);
+    /*
+        const monthCount = await getMonthCount(page);
+    
+        for (const key of new Array(monthCount).keys()) {
+            // Don't advance the calendar if it's the first month
+            if (key > 0) {
+                await pageService.getNextMonthCalendar(page);
+            }
+            const dailySlotsForMonth = await getDailyAvailabilityCountsForMonth(
+                page,
+                pageService
+            );
+            // Add all day objects to results.availability
+            dailySlotsForMonth.forEach(
+                (value, key) => (results.availability[key] = value)
+            );
         }
-        const dailySlotsForMonth = await getDailyAvailabilityCountsForMonth(
-            page,
-            pageService
-        );
-        // Add all day objects to results.availability
-        dailySlotsForMonth.forEach(
-            (value, key) => (results.availability[key] = value)
-        );
-    }
-
-    results.hasAvailability = !!Object.keys(results.availability).length;
+    
+        results.hasAvailability = !!Object.keys(results.availability).length;
+    */
 
     return results;
 }

--- a/test/TrinityEMSTest.js
+++ b/test/TrinityEMSTest.js
@@ -61,7 +61,7 @@ describe("TrinityEMS :: test 3 months with availability", function () {
         },
     };
 
-    it(
+    it.skip(
         "Should return 13 slots with an ascending number of available slots, total = 91. " +
             "Should also send s3 and slackMsg notifications once.",
         async () => {
@@ -107,7 +107,7 @@ describe("TrinityEMS :: test with 'no-dates-available' class present", function 
         },
     };
 
-    it("should return no availability", async function () {
+    it.skip("should return no availability", async function () {
         const results = await trinityEms(browser, noDatesPageService);
 
         expect(Object.keys(results.availability).length).to.equal(0);


### PR DESCRIPTION
Actually scraping (and the tests) were commented out for TrinityEMS.

This scraper was getting a TimeoutError.  This is just an attempt to isolate the root cause of the entire Lambda failing.

`TimeoutError: waiting for selector `.scheduleday` failed: timeout 15000ms exceeded`