### PR TITLE
Refactored common scraper code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ proprietary/
 *.zip
 lambda/
 out.json
+out_no_browser.json
 .eslintrc.json
 .vscode/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -20,12 +20,23 @@ This is the open-source portion of the back-end, website scraping software that 
 
 ## Using this code
 
+There are two separate lambdas -- scrapers that use Puppeteer browsers, and scrapers that don't use a browser.
 1. In your terminal, install dependencies with `npm install`
+
+### Puppeteer Scrapers
+
 1. To run all scrapers: `node scraper.js`
    To run an individual scraper, specify the base filename from site-scrapers, e.g.:
    `node scraper.js MAImmunizations`
    to run `site-scrapers/MAImmunizations`
 1. If you have your own scrapers you want to add, mimic the structure of `./site-scrapers/` inside a folder structure named `proprietary/site-scrapers`. In your .env file, have the field `PROPRIETARY_SITE_SCRAPERS_PATH` set `./../proprietary/site-scrapers`. This naming is recommended since the `.gitignore` lists the folder `proprietary`.
+
+### No-Browser Scrapers
+1. To run all scrapers: `node scrapers-no-browser.js`
+   To run an individual scraper, specify the base filename from no-browser-site-scrapers, e.g.:
+   `node scrapers-no-browser.js Color`
+   to run `no-browser-site-scrapers/Color`
+1. If you have your own scrapers you want to add, mimic the structure of `./no-browser-site-scrapers/` inside a folder structure named `proprietary/no-browser-site-scrapers`. In your .env file, have the field `PROPRIETARY_NO_BROWSER_SITE_SCRAPERS_PATH` set `./../proprietary/no-browser-site-scrapers`. This naming is recommended since the `.gitignore` lists the folder `proprietary`.
 
 ## Continuous Deployment
 

--- a/no-browser-site-scrapers/index.js
+++ b/no-browser-site-scrapers/index.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 
 let scrapers = [];
 
-// args override directory list allowing single site runs, e.g. `node main.js LynnTech`
+// args override directory list allowing single site runs, e.g. `node scrapers_no_browser.js LynnTech`
 if (process.argv.length > 2) {
     for (let i = 2; i < process.argv.length; i++) {
         const scraper = require(`./${process.argv[i]}`);
@@ -23,8 +23,9 @@ if (process.argv.length > 2) {
     });
 }
 
-if (process.env.PROPRIETARY_SITE_SCRAPERS_PATH) {
-    const otherScrapers = require(process.env.PROPRIETARY_SITE_SCRAPERS_PATH);
+if (process.env.PROPRIETARY_NO_BROWSER_SITE_SCRAPERS_PATH) {
+    const otherScrapers = require(process.env
+        .PROPRIETARY_NO_BROWSER_SITE_SCRAPERS_PATH);
     scrapers.push(...otherScrapers);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1833,7 +1833,22 @@
             "resolved": "https://registry.npmjs.org/lambdafs/-/lambdafs-2.0.3.tgz",
             "integrity": "sha512-5YWwZA/QKk09GdfcJ/ABVO+bpFoGlnTBa5jmyM8Kt9yIzl2lDDVBPLK+Aenq2UEcuDpqxXIYI5zLB7VZNepTrg==",
             "bundleDependencies": [
-                "tar-fs"
+                "tar-fs",
+                "base64-js",
+                "bl",
+                "buffer",
+                "chownr",
+                "end-of-stream",
+                "fs-constants",
+                "ieee754",
+                "inherits",
+                "mkdirp-classic",
+                "once",
+                "pump",
+                "string_decoder",
+                "tar-stream",
+                "util-deprecate",
+                "wrappy"
             ],
             "dependencies": {
                 "tar-fs": "^2.1.1"

--- a/scraper.js
+++ b/scraper.js
@@ -119,7 +119,7 @@ async function execute() {
         if (process.env.DEVELOPMENT) {
             //console.log("The following data would be published:");
             //console.dir(responseJson, { depth: null });
-            file.write("out_no_browser.json", webData);
+            file.write("out.json", webData);
             logGlobalMetric("SuccessfulRun", 1, new Date());
             logGlobalMetric(
                 "Duration",

--- a/scraper.js
+++ b/scraper.js
@@ -2,155 +2,19 @@ const dotenv = require("dotenv");
 //note: this only works locally; in Lambda we use environment variables set manually
 dotenv.config();
 
-const chromium = require("chrome-aws-lambda");
-const { addExtra } = require("puppeteer-extra");
-const Puppeteer = addExtra(chromium.puppeteer);
+const scrapers = require("./site-scrapers");
+const scraperCommon = require("./scraper_common.js");
 
-const { getAllCoordinates } = require("./getGeocode");
-const {
-    logGlobalMetric,
-    logScraperRun,
-    getTotalNumberOfAppointments,
-} = require("./lib/metrics");
-const dataDefaulter = require("./data/dataDefaulter");
-const fetch = require("node-fetch");
-const file = require("./lib/file");
-const Recaptcha = require("puppeteer-extra-plugin-recaptcha");
-const scrapers = require("./site-scrapers").reverse();
-const StealthPlugin = require("puppeteer-extra-plugin-stealth");
-const s3 = require("./lib/s3");
-
-async function execute() {
-    const globalStartTime = new Date();
-    Puppeteer.use(StealthPlugin());
-
-    Puppeteer.use(
-        Recaptcha({
-            provider: { id: "2captcha", token: process.env.RECAPTCHATOKEN },
-        })
-    );
-
-    const browser = process.env.DEVELOPMENT
-        ? await Puppeteer.launch({
-              executablePath: process.env.CHROMEPATH,
-              headless: true,
-          })
-        : await Puppeteer.launch({
-              args: [...chromium.args, "--single-process"],
-              defaultViewport: chromium.defaultViewport,
-              executablePath: await chromium.executablePath,
-              headless: chromium.headless,
-              ignoreHTTPSErrors: true,
-          });
-
-    const gatherData = async () => {
-        const results = [];
-        for (const scraper of scrapers) {
-            const startTime = new Date();
-            let isSuccess = true;
-            const returnValue = await scraper
-                .run(browser)
-                .catch((error) => {
-                    //print out the issue but don't fail, this way we still publish updates
-                    //for other locations even if this website's scrape doesn't work
-                    console.log(error);
-                    isSuccess = false;
-                    return null;
-                })
-                .then(async (result) => {
-                    const numberAppointments = getTotalNumberOfAppointments(
-                        result
-                    );
-                    // TODO - call FaunaDB util method here!
-                    await logScraperRun(
-                        scraper.name,
-                        isSuccess,
-                        new Date() - startTime,
-                        startTime,
-                        numberAppointments
-                    );
-                    return result;
-                });
-            results.push(returnValue);
-        }
-        await browser.close();
-        let scrapedResultsArray = [];
-        for (const result of results) {
-            if (Array.isArray(result)) {
-                scrapedResultsArray.push(...result);
-            } else if (result) {
-                //ignore nulls
-                scrapedResultsArray.push(result);
-            }
-        }
-
-        const cachedResults = await fetch(
-            "https://mzqsa4noec.execute-api.us-east-1.amazonaws.com/prod"
-        )
-            .then((res) => res.json())
-            .then((unpack) => JSON.parse(unpack.body).results);
-
-        let finalResultsArray = [];
-        if (process.argv.length <= 2) {
-            // Only add default data if we're not testing individual scrapers.
-            // We are not passing in the optional 3rd arg of mergeResults;
-            // this means that there is no time limit on stale data being merged in.
-            finalResultsArray = dataDefaulter.mergeResults(
-                scrapedResultsArray,
-                cachedResults
-            );
-        } else {
-            finalResultsArray = scrapedResultsArray;
-        }
-
-        const responseJson = {
-            // Version number of the file
-            version: 1,
-
-            // Timestamp for the archived data.json file.
-            timestamp: s3.getTimestampForFile(),
-
-            // Add geocoding for all locations
-            results: await getAllCoordinates(finalResultsArray, cachedResults),
-        };
-
-        const webData = JSON.stringify(responseJson);
-
-        if (process.env.DEVELOPMENT) {
-            console.log("The data that would be published is in 'out.json'");
-            //console.log("The following data would be published:");
-            //console.dir(responseJson, { depth: null });
-            file.write("out.json", webData);
-            logGlobalMetric("SuccessfulRun", 1, new Date());
-            logGlobalMetric(
-                "Duration",
-                new Date() - globalStartTime,
-                new Date()
-            );
-            return responseJson;
-        } else {
-            const uploadResponse = await s3.saveWebData(
-                webData,
-                responseJson.timestamp
-            );
-            logGlobalMetric("SuccessfulRun", 1, new Date());
-            logGlobalMetric(
-                "Duration",
-                new Date() - globalStartTime,
-                new Date()
-            );
-            return uploadResponse;
-        }
-    };
-    await gatherData();
+async function executeScrapers() {
+    await scraperCommon.execute(true, scrapers);
 }
 
-exports.handler = execute;
+exports.handler = executeScrapers;
 
 if (process.env.DEVELOPMENT) {
     (async () => {
         console.log("DEV MODE");
-        await execute();
+        await executeScrapers();
         process.exit();
     })();
 }

--- a/scraper.js
+++ b/scraper.js
@@ -117,6 +117,7 @@ async function execute() {
         const webData = JSON.stringify(responseJson);
 
         if (process.env.DEVELOPMENT) {
+            console.log("The data that would be published is in 'out.json'");
             //console.log("The following data would be published:");
             //console.dir(responseJson, { depth: null });
             file.write("out.json", webData);

--- a/scraper_common.js
+++ b/scraper_common.js
@@ -16,7 +16,6 @@ const dataDefaulter = require("./data/dataDefaulter");
 const fetch = require("node-fetch");
 const file = require("./lib/file");
 const Recaptcha = require("puppeteer-extra-plugin-recaptcha");
-//const scrapers = require("./site-scrapers").reverse();
 const StealthPlugin = require("puppeteer-extra-plugin-stealth");
 const s3 = require("./lib/s3");
 
@@ -130,7 +129,8 @@ async function execute(usePuppeteer, scrapers) {
             //console.log("The following data would be published:");
             //console.dir(responseJson, { depth: null });
             file.write(outFile, webData);
-            /*
+
+            /* -- Don't record metrics in development --
             logGlobalMetric(
                 usePuppeteer ? "SuccessfulRun" : "SuccessfulNoBrowserRun",
                 1,

--- a/scraper_common.js
+++ b/scraper_common.js
@@ -130,12 +130,18 @@ async function execute(usePuppeteer, scrapers) {
             //console.log("The following data would be published:");
             //console.dir(responseJson, { depth: null });
             file.write(outFile, webData);
-            logGlobalMetric("SuccessfulRun", 1, new Date());
+            /*
             logGlobalMetric(
-                "Duration",
+                usePuppeteer ? "SuccessfulRun" : "SuccessfulNoBrowserRun",
+                1,
+                new Date()
+            );
+            logGlobalMetric(
+                usePuppeteer ? "Duration" : "NoBrowserDuration",
                 new Date() - globalStartTime,
                 new Date()
             );
+            */
             return responseJson;
         } else {
             const uploadResponse = await s3.saveWebData(

--- a/scraper_common.js
+++ b/scraper_common.js
@@ -1,0 +1,161 @@
+const dotenv = require("dotenv");
+//note: this only works locally; in Lambda we use environment variables set manually
+dotenv.config();
+
+const chromium = require("chrome-aws-lambda");
+const { addExtra } = require("puppeteer-extra");
+const Puppeteer = addExtra(chromium.puppeteer);
+
+const { getAllCoordinates } = require("./getGeocode");
+const {
+    logGlobalMetric,
+    logScraperRun,
+    getTotalNumberOfAppointments,
+} = require("./lib/metrics");
+const dataDefaulter = require("./data/dataDefaulter");
+const fetch = require("node-fetch");
+const file = require("./lib/file");
+const Recaptcha = require("puppeteer-extra-plugin-recaptcha");
+//const scrapers = require("./site-scrapers").reverse();
+const StealthPlugin = require("puppeteer-extra-plugin-stealth");
+const s3 = require("./lib/s3");
+
+async function execute(usePuppeteer, scrapers) {
+    const globalStartTime = new Date();
+
+    let browser = null;
+    if (usePuppeteer) {
+        Puppeteer.use(StealthPlugin());
+
+        Puppeteer.use(
+            Recaptcha({
+                provider: { id: "2captcha", token: process.env.RECAPTCHATOKEN },
+            })
+        );
+
+        browser = process.env.DEVELOPMENT
+            ? await Puppeteer.launch({
+                  executablePath: process.env.CHROMEPATH,
+                  headless: true,
+              })
+            : await Puppeteer.launch({
+                  args: [...chromium.args, "--single-process"],
+                  defaultViewport: chromium.defaultViewport,
+                  executablePath: await chromium.executablePath,
+                  headless: chromium.headless,
+                  ignoreHTTPSErrors: true,
+              });
+    }
+
+    const gatherData = async () => {
+        const results = [];
+        for (const scraper of scrapers) {
+            const startTime = new Date();
+            let isSuccess = true;
+            const returnValue = await scraper
+                .run(browser)
+                .catch((error) => {
+                    //print out the issue but don't fail, this way we still publish updates
+                    //for other locations even if this website's scrape doesn't work
+                    console.log(error);
+                    isSuccess = false;
+                    return null;
+                })
+                .then(async (result) => {
+                    const numberAppointments = getTotalNumberOfAppointments(
+                        result
+                    );
+                    // TODO - call FaunaDB util method here!
+                    await logScraperRun(
+                        scraper.name,
+                        isSuccess,
+                        new Date() - startTime,
+                        startTime,
+                        numberAppointments
+                    );
+                    return result;
+                });
+            results.push(returnValue);
+        }
+        if (usePuppeteer) {
+            await browser.close();
+        }
+        let scrapedResultsArray = [];
+        for (const result of results) {
+            if (Array.isArray(result)) {
+                scrapedResultsArray.push(...result);
+            } else if (result) {
+                //ignore nulls
+                scrapedResultsArray.push(result);
+            }
+        }
+
+        const cachedResults = await fetch(
+            "https://mzqsa4noec.execute-api.us-east-1.amazonaws.com/prod"
+        )
+            .then((res) => res.json())
+            .then((unpack) => JSON.parse(unpack.body).results);
+
+        let finalResultsArray = [];
+        if (process.argv.length <= 2) {
+            // Only add default data if we're not testing individual scrapers.
+            // We are not passing in the optional 3rd arg of mergeResults;
+            // this means that there is no time limit on stale data being merged in.
+            finalResultsArray = dataDefaulter.mergeResults(
+                scrapedResultsArray,
+                cachedResults
+            );
+        } else {
+            finalResultsArray = scrapedResultsArray;
+        }
+
+        const responseJson = {
+            // Version number of the file
+            version: 1,
+
+            // Timestamp for the archived data.json file.
+            timestamp: s3.getTimestampForFile(),
+
+            // Add geocoding for all locations
+            results: await getAllCoordinates(finalResultsArray, cachedResults),
+        };
+
+        const webData = JSON.stringify(responseJson);
+
+        if (process.env.DEVELOPMENT) {
+            const outFile = usePuppeteer ? "out.json" : "out_no_browser.json";
+            console.log(
+                "The data that would be published is in '" + outFile + "'"
+            );
+            //console.log("The following data would be published:");
+            //console.dir(responseJson, { depth: null });
+            file.write(outFile, webData);
+            logGlobalMetric("SuccessfulRun", 1, new Date());
+            logGlobalMetric(
+                "Duration",
+                new Date() - globalStartTime,
+                new Date()
+            );
+            return responseJson;
+        } else {
+            const uploadResponse = await s3.saveWebData(
+                webData,
+                responseJson.timestamp
+            );
+            logGlobalMetric(
+                usePuppeteer ? "SuccessfulRun" : "SuccessfulNoBrowserRun",
+                1,
+                new Date()
+            );
+            logGlobalMetric(
+                usePuppeteer ? "Duration" : "NoBrowserDuration",
+                new Date() - globalStartTime,
+                new Date()
+            );
+            return uploadResponse;
+        }
+    };
+    await gatherData();
+}
+
+module.exports = { execute };

--- a/scrapers_no_browser.js
+++ b/scrapers_no_browser.js
@@ -3,7 +3,6 @@ const dotenv = require("dotenv");
 dotenv.config();
 
 const noBrowserScrapers = require("./no-browser-site-scrapers");
-//import { executeCommon } from "./scraper_common";
 const scraperCommon = require("./scraper_common.js");
 
 async function executeNoBrowserScrapers() {

--- a/scrapers_no_browser.js
+++ b/scrapers_no_browser.js
@@ -90,7 +90,9 @@ async function execute() {
         const webData = JSON.stringify(responseJson);
 
         if (process.env.DEVELOPMENT) {
-            //console.log("The following data would be published:");
+            console.log(
+                "The data that would be published is in 'out_no_browser.json'"
+            );
             //console.dir(responseJson, { depth: null });
             file.write("out_no_browser.json", webData);
             logGlobalMetric("SuccessfulRun", 1, new Date());

--- a/scrapers_no_browser.js
+++ b/scrapers_no_browser.js
@@ -2,129 +2,20 @@ const dotenv = require("dotenv");
 //note: this only works locally; in Lambda we use environment variables set manually
 dotenv.config();
 
-const { getAllCoordinates } = require("./getGeocode");
-const {
-    logGlobalMetric,
-    logScraperRun,
-    getTotalNumberOfAppointments,
-} = require("./lib/metrics");
-const dataDefaulter = require("./data/dataDefaulter");
-const fetch = require("node-fetch");
-const file = require("./lib/file");
-const scrapers = require("./no-browser-site-scrapers");
-const s3 = require("./lib/s3");
+const noBrowserScrapers = require("./no-browser-site-scrapers");
+//import { executeCommon } from "./scraper_common";
+const scraperCommon = require("./scraper_common.js");
 
-async function execute() {
-    const globalStartTime = new Date();
-
-    const gatherData = async () => {
-        const results = [];
-        for (const scraper of scrapers) {
-            const startTime = new Date();
-            let isSuccess = true;
-            const returnValue = await scraper
-                .run()
-                .catch((error) => {
-                    //print out the issue but don't fail, this way we still publish updates
-                    //for other locations even if this website's scrape doesn't work
-                    console.log(error);
-                    isSuccess = false;
-                    return null;
-                })
-                .then(async (result) => {
-                    const numberAppointments = getTotalNumberOfAppointments(
-                        result
-                    );
-                    // TODO - call FaunaDB util method here!
-                    await logScraperRun(
-                        scraper.name,
-                        isSuccess,
-                        new Date() - startTime,
-                        startTime,
-                        numberAppointments
-                    );
-                    return result;
-                });
-            results.push(returnValue);
-        }
-        let scrapedResultsArray = [];
-        for (const result of results) {
-            if (Array.isArray(result)) {
-                scrapedResultsArray.push(...result);
-            } else if (result) {
-                //ignore nulls
-                scrapedResultsArray.push(result);
-            }
-        }
-
-        const cachedResults = await fetch(
-            "https://mzqsa4noec.execute-api.us-east-1.amazonaws.com/prod"
-        )
-            .then((res) => res.json())
-            .then((unpack) => JSON.parse(unpack.body).results);
-
-        let finalResultsArray = [];
-        if (process.argv.length <= 2) {
-            // Only add default data if we're not testing individual scrapers.
-            // We are not passing in the optional 3rd arg of mergeResults;
-            // this means that there is no time limit on stale data being merged in.
-            finalResultsArray = dataDefaulter.mergeResults(
-                scrapedResultsArray,
-                cachedResults
-            );
-        } else {
-            finalResultsArray = scrapedResultsArray;
-        }
-
-        const responseJson = {
-            // Version number of the file
-            version: 1,
-
-            // Timestamp for the archived data.json file.
-            timestamp: s3.getTimestampForFile(),
-
-            // Add geocoding for all locations
-            results: await getAllCoordinates(finalResultsArray, cachedResults),
-        };
-
-        const webData = JSON.stringify(responseJson);
-
-        if (process.env.DEVELOPMENT) {
-            console.log(
-                "The data that would be published is in 'out_no_browser.json'"
-            );
-            //console.dir(responseJson, { depth: null });
-            file.write("out_no_browser.json", webData);
-            logGlobalMetric("SuccessfulRun", 1, new Date());
-            logGlobalMetric(
-                "Duration",
-                new Date() - globalStartTime,
-                new Date()
-            );
-            return responseJson;
-        } else {
-            const uploadResponse = await s3.saveWebData(
-                webData,
-                responseJson.timestamp
-            );
-            logGlobalMetric("SuccessfulNoBrowserRun", 1, new Date());
-            logGlobalMetric(
-                "NoBrowserDuration",
-                new Date() - globalStartTime,
-                new Date()
-            );
-            return uploadResponse;
-        }
-    };
-    await gatherData();
+async function executeNoBrowserScrapers() {
+    await scraperCommon.execute(false, noBrowserScrapers);
 }
 
-exports.handler = execute;
+exports.handler = executeNoBrowserScrapers;
 
 if (process.env.DEVELOPMENT) {
     (async () => {
         console.log("DEV MODE");
-        await execute();
+        await executeNoBrowserScrapers();
         process.exit();
     })();
 }

--- a/scrapers_no_browser.js
+++ b/scrapers_no_browser.js
@@ -92,7 +92,7 @@ async function execute() {
         if (process.env.DEVELOPMENT) {
             //console.log("The following data would be published:");
             //console.dir(responseJson, { depth: null });
-            file.write("out.json", webData);
+            file.write("out_no_browser.json", webData);
             logGlobalMetric("SuccessfulRun", 1, new Date());
             logGlobalMetric(
                 "Duration",

--- a/site-scrapers/index.js
+++ b/site-scrapers/index.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 
 let scrapers = [];
 
-// args override directory list allowing single site runs, e.g. `node main.js LynnTech`
+// args override directory list allowing single site runs, e.g. `node scraper.js MAImmunizations`
 if (process.argv.length > 2) {
     for (let i = 2; i < process.argv.length; i++) {
         const scraper = require(`./${process.argv[i]}`);


### PR DESCRIPTION
- Refactored the common scraper code into `scraper_common.js`.
- Updated README.md with new calls
- `out.json` and `out_no_browser.json` were switched
- Metrics are only written in production.

The metrics were being updated when somebody ran the local development scraper.  This was confusing when we were attempting to debug the failed production scraper.