### PR TITLE
finishing the rename of Workflow 1 in Workflow 2

### DIFF
--- a/.github/workflows/prod_deploy.yaml
+++ b/.github/workflows/prod_deploy.yaml
@@ -1,7 +1,7 @@
 name: Workflow 2 - SAM Validate, Build, Deploy
 on:
   workflow_run:
-    workflows: ["Workflow 1 - Test"]
+    workflows: ["Workflow 1 - Run Test Suite"]
     branches: [master]
     types:
       - completed


### PR DESCRIPTION
I renamed workflow 1 in a previous PR: https://github.com/livgust/covid-vaccine-scrapers/pull/187
and didn't rename it in the trigger to workflow 2. 

Therefore we aren't deploying on merges to main, which we *really* need to do right now, because we deployed some wrong things in the last hour.