### PR TITLE
MAImmunization: Check for valid Sign up link

### DIFF
--- a/site-scrapers/MAImmunizations/config.js
+++ b/site-scrapers/MAImmunizations/config.js
@@ -3,6 +3,7 @@ const site = {
     website:
         "https://clinics.maimmunizations.org/clinic/search?q%5Bservices_name_in%5D%5B%5D=Vaccination&location=&search_radius=All&q%5Bvenue_search_name_or_venue_name_i_cont%5D=&q%5Bclinic_date_gteq%5D=&q%5Bvaccinations_name_i_cont%5D=&commit=Search&page=1#search_results",
     baseWebsite: "https://www.maimmunizations.org",
+    testSignUpLinkWebsite: "https://clinics.maimmunizations.org",
 };
 
 module.exports = {

--- a/site-scrapers/MAImmunizations/index.js
+++ b/site-scrapers/MAImmunizations/index.js
@@ -109,7 +109,7 @@ async function ScrapeWebsiteData(browser) {
                 //          Clinic does not have any appointment slots available.
                 //      </div>
                 const testSignUpLink = site.testSignUpLinkWebsite + signUpLink;
-                signUpLink = site.website + signUpLink;
+                signUpLink = site.baseWebsite + signUpLink;
 
                 const clinicPage = await browser.newPage();
                 try {

--- a/site-scrapers/MAImmunizations/index.js
+++ b/site-scrapers/MAImmunizations/index.js
@@ -123,7 +123,9 @@ async function ScrapeWebsiteData(browser) {
                     if (response?.url().match(/errors\?message/)) {
                         signUpLink = null; // no availability if there is an alert on the page
                     }
-                } catch (e) {}
+                } catch (e) {
+                    console.error(e);
+                }
             }
 
             results[uniqueID].availability[date] = {

--- a/site-scrapers/MAImmunizations/index.js
+++ b/site-scrapers/MAImmunizations/index.js
@@ -103,7 +103,22 @@ async function ScrapeWebsiteData(browser) {
                   )
                 : null;
             if (signUpLink) {
-                signUpLink = site.baseWebsite + signUpLink;
+                // See if the link has any real availability
+                // The page without availability contains:
+                //      <div class="danger-alert">
+                //          Clinic does not have any appointment slots available.
+                //      </div>
+                const testSignUpLink = site.testSignUpLinkWebsite + signUpLink;
+
+                const clinicPage = await browser.newPage();
+                await clinicPage.goto(testSignUpLink);
+                const dangerAlert = await clinicPage.$$("div.danger-alert");
+
+                if (dangerAlert?.length) {
+                    signUpLink = null; // no availability if there is an alert on the page
+                } else {
+                    signUpLink = site.baseWebsite + signUpLink;
+                }
             }
 
             results[uniqueID].availability[date] = {


### PR DESCRIPTION
2nd Attempt.  PR #189 didn't work because of "Target Closed" error from Puppeteer.

I added a try/catch block and a short timeout to hopefully prevent everything from grinding to a halt.

I also changed the method of detection from the **contents of the page** to the **URL of the page**.  When there are no appointments available, MAImmunizations redirects to `/errors?message=Clinic+does+not+have+any+appointment+slots+available.`