### PR TITLE
start writing data to Fauna database (turn on feature flag)

### DIFF
--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -30,13 +30,14 @@ jobs:
           DEVELOPMENT: true
           CHROMEPATH: /usr/bin/chromium-browser
           FAUNA_DB: ${{ secrets.FAUNA_DB_DEV }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
         run: |
-          if [ -z "${{ secrets.FAUNA_DB_DEV }}" ]
+          if [ -z "${{ secrets.FAUNA_DB_DEV }}" ] || [ -z "${{ secrets.GOOGLE_API_KEY }}" ]
           then
-            echo "\$FAUNA_DB_DEV secret does not exist, skipping Fauna tests"
+            echo "\$FAUNA_DB_DEV or \$GOOGLE_API_KEY secret does not exist, skipping Fauna tests"
             npm test --  --exclude **/db-utils-test.js
           else
-            echo "\$FAUNA_DB_DEV secret does exist, running all tests"
+            echo "Necessary secrets exist, running all tests"
             npm test
           fi
       - run: npx prettier --check ./

--- a/scraper_common.js
+++ b/scraper_common.js
@@ -21,7 +21,7 @@ const s3 = require("./lib/s3");
 const dbUtils = require("./lib/db-utils");
 const moment = require("moment");
 
-WRITE_TO_FAUNA = false;
+WRITE_TO_FAUNA = true;
 
 async function execute(usePuppeteer, scrapers) {
     const globalStartTime = new Date();


### PR DESCRIPTION
Up until now, we've only written to the Fauna in our tests, and some folks have done so in their dev environments. 

Now, I'm flipping `WRITE_TO_FAUNA` to true, so that when our prod lambda runs, we will start writing real data to the prod database. 

This var is used on line 89: `if (WRITE_TO_FAUNA && process.env.FAUNA_DB)` - if that evaluates to true, then we write to Fauna. 

If you wish to write to the Fauna DB, you'll need to set the `FAUNA_DB` env var. (You can DM me for this). If you don't want to write to the Fauna DB, you can leave your env var unset (or temporarily set `WRITE_TO_FAUNA` back to false while you're in the development process).