### PR TITLE
remove check for test success before deploying

### DIFF
--- a/.github/workflows/prod_deploy.yaml
+++ b/.github/workflows/prod_deploy.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   sam-validate-build-deploy:
-    if: ${{ github.repository_owner == 'livgust' && github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.repository_owner == 'livgust' }}
     runs-on: ubuntu-latest
     outputs:
       env-name: ${{ steps.env-name.outputs.environment }}


### PR DESCRIPTION
So that we can still deploy code when there's an issue with a test, we want to deploy on all merges to master after tests finish (but do not necessarily succeed). 