### PR TITLE
test/LowellGeneral.js: fast fix on year

### DIFF
--- a/test/LowellGeneral.js
+++ b/test/LowellGeneral.js
@@ -17,7 +17,7 @@ describe("GetAvailabilities", () => {
         const resultingAvailability = {
             hasAvailability: true,
             availability: {
-                "03/21/2021": {
+                "03/21/2022": {
                     hasAvailability: true,
                     numberAvailableAppointments: 2,
                 },


### PR DESCRIPTION
We moved into April and things changed. The logic is broken, but we
should not block merging of all other PRS while we fix it.