### PR TITLE
test/*.js: Ensure tests .describe() a unique name

### DIFF
--- a/test/AtriusTest.js
+++ b/test/AtriusTest.js
@@ -5,7 +5,7 @@ const chai = require("chai");
 chai.use(require("chai-as-promised"));
 const expect = chai.expect;
 
-describe("GetAvailabilities", () => {
+describe("Atrius GetAvailabilities", () => {
     it("should return no availabilities when there is a redirect", () => {
         const atrius = require("./../no-browser-site-scrapers/Atrius");
         // mock out the redirect that occurs when there Atrius doesn't want to show any slots.

--- a/test/Color.js
+++ b/test/Color.js
@@ -3,7 +3,7 @@ const { formatResponse } = require("./../no-browser-site-scrapers/Color");
 const chai = require("chai");
 const expect = chai.expect;
 
-describe("Transformations", () => {
+describe("Color Transformations", () => {
     it("should return no availabilities when there is -1", () => {
         // mock out the availability request
         const response = `{"results": [{

--- a/test/LowellGeneral.js
+++ b/test/LowellGeneral.js
@@ -4,7 +4,7 @@ const mock = require("mock-require");
 const chai = require("chai");
 const expect = chai.expect;
 
-describe("GetAvailabilities", () => {
+describe("LowellGeneral GetAvailabilities", () => {
     it("should return availabilities when there are availabilities", async () => {
         const {
             buildTimeSlotsUrl,

--- a/test/MyChartAPITest.js
+++ b/test/MyChartAPITest.js
@@ -365,7 +365,7 @@ const exampleWithError = {
     VisitTypeInfo: null,
 };
 
-describe("AddSiteInfo", () => {
+describe("MyChartAPI AddSiteInfo", () => {
     it("should add site info and default data to results object", () => {
         results = {};
         siteKey = Object.keys(exampleWithAvailability.AllDepartments)[0];
@@ -389,7 +389,7 @@ describe("AddSiteInfo", () => {
     });
 });
 
-describe("CommonPostDataCallback", () => {
+describe("MyChartAPI CommonPostDataCallback", () => {
     it("should return a function", () => {
         const res = mychart.CommonPostDataCallback([], [], "");
         expect(res).to.be.a("function");
@@ -425,7 +425,7 @@ describe("CommonPostDataCallback", () => {
     });
 });
 
-describe("UpdateResults", () => {
+describe("MyChartAPI UpdateResults", () => {
     it("should add site info and default data to results object", () => {
         results = {};
         mychart.UpdateResults(results, exampleWithAvailability);

--- a/test/PriceChopper.js
+++ b/test/PriceChopper.js
@@ -5,7 +5,7 @@ const chai = require("chai");
 chai.use(require("chai-subset"));
 const expect = chai.expect;
 
-describe("GetAvailabilities", () => {
+describe("PriceChopper GetAvailabilities", () => {
     it("should return availabilities when there are availabilities", async () => {
         const scraper = require("../no-browser-site-scrapers/PriceChopper");
 

--- a/test/WalgreensDataFormatter.js
+++ b/test/WalgreensDataFormatter.js
@@ -134,7 +134,7 @@ const exampleStoreList = [
     },
 ];
 
-describe("formatData", () => {
+describe("WalgreensDataFormatter formatData", () => {
     const { signUpLink, hasAvailability, availability, ...result } = formatData(
         [exampleEntry],
         fakeWebsite
@@ -171,7 +171,7 @@ describe("formatData", () => {
     });
 });
 
-describe("extendData", () => {
+describe("WalgreensDataFormatter extendData", () => {
     const allSites = [
         { street: "1010 Broadway", city: "Chelsea", zip: "02150" },
         { street: "107 High St", city: "Danvers", zip: "01923" },
@@ -240,7 +240,7 @@ describe("extendData", () => {
     });
 });
 
-describe("getFormattedUnavailableStores", () => {
+describe("WalgreensDataFormatter getFormattedUnavailableStores", () => {
     it("formats the stores correctly", () => {
         expect(
             getFormattedUnavailableStores({}, exampleStoreList)

--- a/test/ZocDocTest.js
+++ b/test/ZocDocTest.js
@@ -12,7 +12,7 @@ const { locationData } = require("./ZocDoc/location-data");
  * This test the config generator utility. Not a part of scraping but gathering
  * info from fetching provider data from ZocDoc. Automates site info creation.
  */
-describe.skip("Config generator test", function () {
+describe.skip("ZocDoc Config generator test", function () {
     it("should provide id, name and location for each site", async function () {
         const providerDetailsJson = locationData; // await generator.fetchProviderDetails();
         const providerDetails = generator.parseProviderDetails(
@@ -27,7 +27,7 @@ describe.skip("Config generator test", function () {
     });
 });
 
-describe("Provider availability test using scraper and canned data", function () {
+describe("ZocDoc Provider availability test using scraper and canned data", function () {
     const testFetchService = {
         async fetchAvailability() {
             return someAvailability;
@@ -63,7 +63,7 @@ describe("Provider availability test using scraper and canned data", function ()
     });
 });
 
-describe.skip("Testing zocdocBase with canned data", function () {
+describe.skip("ZocDoc Testing zocdocBase with canned data", function () {
     it("should provide availability for each site", async function () {
         const providerAvailabilityJson = await helper.fetchAvailability();
 

--- a/test/dataDefaulter.js
+++ b/test/dataDefaulter.js
@@ -72,7 +72,7 @@ const realisticDefaultData = [
     },
 ];
 
-describe("Simple behavior", () => {
+describe("dataDefaulter Simple behavior", () => {
     it("should return scraped results when no cache values are present", () => {
         assert.deepStrictEqual(
             dataDefaulter.mergeResults(realisticTestData, []),
@@ -87,7 +87,7 @@ describe("Simple behavior", () => {
     });
 });
 
-describe("Conditionally inserting defaults", () => {
+describe("dataDefaulter Conditionally inserting defaults", () => {
     const finalResults = dataDefaulter.mergeResults(
         realisticTestData,
         realisticDefaultData
@@ -107,7 +107,7 @@ describe("Conditionally inserting defaults", () => {
     });
 });
 
-describe("Tolerance for stale data", () => {
+describe("dataDefaulter Tolerance for stale data", () => {
     const secondsOfTolerance = 60;
     it("does not include stale data if specified", () => {
         const timestampedDefault = {
@@ -140,7 +140,7 @@ describe("Tolerance for stale data", () => {
     });
 });
 
-describe("Key generator", () => {
+describe("dataDefaulter Key generator", () => {
     it("generates the expected key", () => {
         assert.strictEqual(
             dataDefaulter.generateKey(realisticTestData[1]),

--- a/test/metrics.js
+++ b/test/metrics.js
@@ -2,7 +2,7 @@ const { getTotalNumberOfAppointments } = require("../lib/metrics");
 const chai = require("chai");
 const expect = chai.expect;
 
-describe("getTotalNumberOfAppointments", () => {
+describe("metrics getTotalNumberOfAppointments", () => {
     it("works for null result", () => {
         expect(getTotalNumberOfAppointments(null)).to.be.equal(0);
     });


### PR DESCRIPTION
Mocha filters and reports tests by the name in .describe(), which
should be both globally unique, and should also reference the module
name, either literally or by variable expansion (which seems to work
in these cases although before there were problems?)