### PR TITLE
Remove Walgreens availability

### DIFF
--- a/site-scrapers/Walgreens/dataFormatter.js
+++ b/site-scrapers/Walgreens/dataFormatter.js
@@ -85,33 +85,36 @@ function formatData(data, website) {
     return data.map((entry) => {
         let hasAvailability = false;
         const availability = {};
-        /*
-    // QUICK FIX: Walgreens is showing FIRST DOSE availability but won't
-    // let the patient schedule anything because there are no SECOND DOSES available
-    // See Issue #200 (https://github.com/livgust/covid-vaccine-scrapers/issues/200)
-        entry.appointmentAvailability.forEach((daySlot) => {
-            const date = moment(daySlot.date).local().startOf("day");
-            const midnightToday = moment().local().startOf("day");
-            if (date.isSame(midnightToday)) {
-                const todaySlots = daySlot.slots.filter((slot) =>
-                    moment(slot, "HH:mm a").isAfter(moment().local())
-                );
-                const numSlots = todaySlots.length;
-                availability[date.format("M/D/YYYY")] = {
-                    hasAvailability: !!numSlots,
-                    numberAvailableAppointments: numSlots,
-                };
-                hasAvailability = hasAvailability || !!numSlots;
-            } else if (date.isAfter(midnightToday)) {
-                const numSlots = daySlot.slots.length;
-                availability[date.format("M/D/YYYY")] = {
-                    hasAvailability: !!numSlots,
-                    numberAvailableAppointments: numSlots,
-                };
-                hasAvailability = hasAvailability || !!numSlots;
-            }
-        });
-*/
+        // PROBLEM: Walgreens is showing FIRST DOSE availability but won't
+        // let the patient schedule anything because there are no SECOND DOSES available
+        // See Issue #200 (https://github.com/livgust/covid-vaccine-scrapers/issues/200)
+
+        // QUICK FIX: Don't report any availability until the following date.
+        const stopUntilDate = new Date("2021-04-02T12:00:00-04:00");
+        if (new Date() >= stopUntilDate) {
+            entry.appointmentAvailability.forEach((daySlot) => {
+                const date = moment(daySlot.date).local().startOf("day");
+                const midnightToday = moment().local().startOf("day");
+                if (date.isSame(midnightToday)) {
+                    const todaySlots = daySlot.slots.filter((slot) =>
+                        moment(slot, "HH:mm a").isAfter(moment().local())
+                    );
+                    const numSlots = todaySlots.length;
+                    availability[date.format("M/D/YYYY")] = {
+                        hasAvailability: !!numSlots,
+                        numberAvailableAppointments: numSlots,
+                    };
+                    hasAvailability = hasAvailability || !!numSlots;
+                } else if (date.isAfter(midnightToday)) {
+                    const numSlots = daySlot.slots.length;
+                    availability[date.format("M/D/YYYY")] = {
+                        hasAvailability: !!numSlots,
+                        numberAvailableAppointments: numSlots,
+                    };
+                    hasAvailability = hasAvailability || !!numSlots;
+                }
+            });
+        }
         return {
             name: `Walgreens (${toTitleCase(entry.address.city)})`, // NOTE: change to "entry.name" if we use the commented-out code above
             street: toTitleCase(

--- a/site-scrapers/Walgreens/dataFormatter.js
+++ b/site-scrapers/Walgreens/dataFormatter.js
@@ -85,6 +85,10 @@ function formatData(data, website) {
     return data.map((entry) => {
         let hasAvailability = false;
         const availability = {};
+        /*
+    // QUICK FIX: Walgreens is showing FIRST DOSE availability but won't
+    // let the patient schedule anything because there are no SECOND DOSES available
+    // See Issue #200 (https://github.com/livgust/covid-vaccine-scrapers/issues/200)
         entry.appointmentAvailability.forEach((daySlot) => {
             const date = moment(daySlot.date).local().startOf("day");
             const midnightToday = moment().local().startOf("day");
@@ -107,6 +111,7 @@ function formatData(data, website) {
                 hasAvailability = hasAvailability || !!numSlots;
             }
         });
+*/
         return {
             name: `Walgreens (${toTitleCase(entry.address.city)})`, // NOTE: change to "entry.name" if we use the commented-out code above
             street: toTitleCase(

--- a/test/WalgreensDataFormatter.js
+++ b/test/WalgreensDataFormatter.js
@@ -151,7 +151,8 @@ describe("formatData", () => {
         ]);
     });
 
-    it("filters out and formats availability", () => {
+    // QUICK FIX: Removed until Issue #200 is fixed
+    it.skip("filters out and formats availability", () => {
         const expectedAvailability = {};
         expectedAvailability[now.format("M/D/YYYY")] = {
             hasAvailability: false,


### PR DESCRIPTION
 Remove Walgreens availability until Noon on April 2nd to give Walgreens time to get their act together.
 Issue #200 is another solution.

Right now, our site is cluttered with Walgreens availability, but you cannot schedule the 1st dose because there are no 2nd doses available 3-4 weeks out.