### PR TITLE
Add logic to utils/tests for reading data from Fauna

### DIFF
--- a/lib/db-utils.js
+++ b/lib/db-utils.js
@@ -337,13 +337,45 @@ async function getScraperRunsByLocation(locationRefId) {
     return scraperRuns;
 }
 
+async function getScraperRunsByLocationsSortedByTimestamp(locations) {
+    const queries = locations.map((loc) =>
+        fq.Map(
+            fq.Paginate(
+                fq.Match(
+                    fq.Index("scraperRunsByLocationRefSortByTimestamp"),
+                    fq.Ref(fq.Collection("locations"), loc.ref.id)
+                )
+            ),
+            fq.Lambda(["ts", "ref"], fq.Get(fq.Var("ref")))
+        )
+    );
+
+    const scraperRuns = await faunaQuery(queries);
+    return scraperRuns;
+}
+
+async function getScraperRunsByLocationSortedByTimestamp(location) {
+    const query = fq.Map(
+        fq.Paginate(
+            fq.Match(
+                fq.Index("scraperRunsByLocationRefSortByTimestamp"),
+                fq.Ref(fq.Collection("locations"), location.ref.id)
+            )
+        ),
+        fq.Lambda(["ts", "ref"], fq.Get(fq.Var("ref")))
+    );
+
+    const scraperRuns = await faunaQuery(query);
+    return scraperRuns;
+}
+
 async function getScraperRunsByLocations(locations) {
     const queries = locations.map((loc) =>
         fq.Map(
             fq.Paginate(
                 fq.Match(
                     fq.Index("scraperRunsByLocation"),
-                    fq.Ref(fq.Collection("locations"), loc.refId)
+                    fq.Ref(fq.Collection("locations"), loc.ref.id)
                 )
             ),
             fq.Lambda((x) => fq.Get(x))
@@ -458,8 +490,7 @@ async function writeScrapedData({
                             numberAvailable:
                                 dateAvailability.numberAvailableAppointments ||
                                 null,
-                            signUpLink:
-                                dateAvailability.signUpLink || signUpLink,
+                            signUpLink: dateAvailability.signUpLink || null,
                         });
                     }
                 }
@@ -502,17 +533,67 @@ async function writeScrapedDataBatch(locations, timestamp) {
     writeAppointmentsByRefIds(locationsWithAllData);
 }
 
+async function getAppointmentsForGivenLocations(locations) {
+    const finalResults = await Promise.all(
+        locations.map(async (location) => {
+            const scraperRuns = await getScraperRunsByLocationSortedByTimestamp(
+                location
+            );
+            const appointmentsForMostRecentScraperRun = await getAppointmentsByScraperRun(
+                scraperRuns.data[0].ref.id
+            );
+            const availability = appointmentsForMostRecentScraperRun.data.reduce(
+                (acc, curr) => {
+                    return {
+                        ...acc,
+                        [curr.data.date]: {
+                            hasAvailability: true,
+                            numberAvailableAppointments:
+                                curr.data.numberAvailable,
+                            signUpLink: curr.data.signUpLink || null,
+                        },
+                    };
+                },
+                {}
+            );
+
+            return {
+                name: location.data.name || null,
+                street: location.data.address?.street || null,
+                city: location.data.address?.city || null,
+                zip: location.data.address?.zip || null,
+                availability,
+                hasAvailability:
+                    Object.keys(availability).length === 0 ? false : true,
+                extraData: location.data.extraData || null,
+                timestamp: scraperRuns.data[0].data.timestamp || null,
+                signUpLink: location.data.signUpLink || null,
+                restrictions: location.data.restrictions || null,
+                massVax: location.data.massVax || null,
+                siteTimestamp: scraperRuns.data[0].data.siteTimestamp || null,
+                latitude: location.data.latitude || null,
+                longitude: location.data.longitude || null,
+            };
+        })
+    );
+    return finalResults;
+}
+
 /* 
     Utility that will return all availability for each location's most recent scraper run.
     This will go into a lambda.
 */
-async function getAppointmentsForAllLocations() {}
+async function getAppointmentsForAllLocations() {
+    // get all locations
+    // call getAppointmentsForGivenLocations
+}
 
 module.exports = {
     addGeneratedIdsToLocations,
     checkItemExistsByRefId,
     checkItemsExistByRefIds,
     getAppointmentsForAllLocations,
+    getAppointmentsForGivenLocations,
     getAppointmentsByScraperRun,
     getAppointmentsByScraperRuns,
     deleteItemByRefId,
@@ -520,6 +601,7 @@ module.exports = {
     generateLocationId,
     getScraperRunsByLocation,
     getScraperRunsByLocations,
+    getScraperRunsByLocationsSortedByTimestamp,
     retrieveItemByRefId,
     retrieveItemsByRefIds,
     writeAppointmentsByRefId,

--- a/lib/db-utils.js
+++ b/lib/db-utils.js
@@ -533,7 +533,10 @@ async function writeScrapedDataBatch(locations, timestamp) {
     writeAppointmentsByRefIds(locationsWithAllData);
 }
 
-async function getAppointmentsForGivenLocations(locations) {
+/* 
+    Utility that will return all availability results for a few given locations' most recent scraper run.
+*/
+async function getResultsForGivenLocations(locations) {
     const finalResults = await Promise.all(
         locations.map(async (location) => {
             const scraperRuns = await getScraperRunsByLocationSortedByTimestamp(
@@ -580,20 +583,26 @@ async function getAppointmentsForGivenLocations(locations) {
 }
 
 /* 
-    Utility that will return all availability for each location's most recent scraper run.
-    This will go into a lambda.
+    Utility that will return all availability results for each location's most recent scraper run.
+    This will go into a lambda. Our tests don't call this because it depends on the state of the Locations collection.
 */
-async function getAppointmentsForAllLocations() {
-    // get all locations
-    // call getAppointmentsForGivenLocations
+async function getResultsForAllLocations() {
+    const query = fq.Map(
+        fq.Paginate(Documents(Collection("locations"))),
+        fq.Lambda((x) => fq.Get(x))
+    );
+    const allLocations = await faunaQuery(query);
+
+    const results = getResultsForGivenLocations(allLocations);
+    return results;
 }
 
 module.exports = {
     addGeneratedIdsToLocations,
     checkItemExistsByRefId,
     checkItemsExistByRefIds,
-    getAppointmentsForAllLocations,
-    getAppointmentsForGivenLocations,
+    getResultsForAllLocations,
+    getResultsForGivenLocations,
     getAppointmentsByScraperRun,
     getAppointmentsByScraperRuns,
     deleteItemByRefId,

--- a/test/db-utils-test.js
+++ b/test/db-utils-test.js
@@ -17,7 +17,7 @@ describe("FaunaDB Utils", function () {
         };
         const generatedId = dbUtils.generateLocationId({
             name: location.name,
-            steet: location.address.street,
+            street: location.address.street,
             city: location.address.city,
             zip: location.address.zip,
         });

--- a/test/db-utils-test.js
+++ b/test/db-utils-test.js
@@ -562,7 +562,6 @@ describe("FaunaDB Utils", function () {
     ).timeout(5000);
 
     it("can get the availability for all locations' most recent scraper runs", async () => {
-        await dbUtils.getAppointmentsForAllLocations();
         // Write data from a scraper.
         const randomName1 = Math.random().toString(36).substring(7);
         const scrapedData1 = {
@@ -666,8 +665,8 @@ describe("FaunaDB Utils", function () {
             [generatedId1, generatedId2]
         );
 
-        // This is the meat of the test - get the appointments for these given locations.
-        const output = await dbUtils.getAppointmentsForGivenLocations(
+        // This is the meat of the test - get the results (all scraper data, combined) for these given locations.
+        const output = await dbUtils.getResultsForGivenLocations(
             locationsInCollection
         );
 

--- a/test/db-utils-test.js
+++ b/test/db-utils-test.js
@@ -561,7 +561,7 @@ describe("FaunaDB Utils", function () {
         }
     ).timeout(5000);
 
-    it("can get the availability for all locations' most recent scraper runs", async () => {
+    it("can get the full results objects for the given locations' most recent scraper runs", async () => {
         // Write data from a scraper.
         const randomName1 = Math.random().toString(36).substring(7);
         const scrapedData1 = {


### PR DESCRIPTION
Implemented `getResultsForAllLocations()` and its dependent `getResultsForGivenLocations()`.
The first will be used in a lambda and depends on the state of the Locations collection, so I haven't tested this yet.
The second has corresponding tests. 

`getResultsForGivenLocations()` also relies on a call to a new index we added, which returns the scraperRuns from newest to oldest. 

Also fixed some `signUpLinks` stuff. I'm pretty sure we don't want to supersede a given date's `signUpLink` (even if it's null) with the scraper-level `signUpLink`. 
And skipped the `given a batch of scrapers outputs...` test, because we don't rely on the batching logic. I plan to remove the logic in a future PR but it was more effort than it was worth to update the tests accordingly. 