### PR TITLE
Set the timestamp on "individual" locations

### DIFF
--- a/no-browser-site-scrapers/CVSPharmacy/index.js
+++ b/no-browser-site-scrapers/CVSPharmacy/index.js
@@ -55,7 +55,6 @@ module.exports = async function GetAvailableAppointments() {
                 name: `${site.name} (${city})`,
                 hasAvailability: responseLocation.status !== "Fully Booked",
                 availability: {},
-                timestamp: moment().format(),
                 siteTimestamp: timestamp,
                 signUpLink: site.website,
             };

--- a/scraper_common.js
+++ b/scraper_common.js
@@ -76,10 +76,9 @@ async function execute(usePuppeteer, scrapers) {
                 numberAppointments
             );
 
-            // Add the current timestamp to each individual location
-            const nowTimestamp = moment().format();
+            // Add the parentLocation's timestamp to each individual location
             returnValue?.individualLocationData.map((loc) => {
-                loc.timestamp = nowTimestamp;
+                loc.timestamp = returnValue.timestamp;
             });
 
             // Save the individualLocationData for the out.json file.

--- a/scraper_common.js
+++ b/scraper_common.js
@@ -75,7 +75,16 @@ async function execute(usePuppeteer, scrapers) {
                 startTime,
                 numberAppointments
             );
+
+            // Add the current timestamp to each individual location
+            const nowTimestamp = moment().format();
+            returnValue?.individualLocationData.map((loc) => {
+                loc.timestamp = nowTimestamp;
+            });
+
+            // Save the individualLocationData for the out.json file.
             results.push(returnValue?.individualLocationData);
+
             // Coerce the results into the format we want.
             let returnValueArray = [];
             if (Array.isArray(returnValue?.individualLocationData)) {

--- a/site-scrapers/Harrington/index.js
+++ b/site-scrapers/Harrington/index.js
@@ -42,7 +42,6 @@ module.exports = async function GetAvailableAppointments(
         allResults.push({
             ...unRestricted,
             ...unRestrictedAvailability,
-            timestamp: moment().format(),
         });
     } catch (error) {
         console.error(`Harrington :: GetAvailableAppointments(): ${error}`);

--- a/site-scrapers/Walgreens/dataFormatter.js
+++ b/site-scrapers/Walgreens/dataFormatter.js
@@ -39,7 +39,6 @@ function formatData(data, website) {
             signUpLink: website,
             hasAvailability,
             availability: availability,
-            timestamp: new Date(),
         };
     });
 }


### PR DESCRIPTION
During the Fauna reorganization, the `timestamp` for individual locations was removed.  The front-end expects this timestamp in every location entry in the production JSON file.  It is used to determine the _staleness_ of the data, and for the merging of data from prior runs.

I removed the `timestamp` from the three scrapers that were still setting it (Walgreens, CVSPharmacy, and Harrington).

Rather than change every scraper, I chose to add the `timestamp` in the common scraper code.  

The timestamp is added **prior to the write** to the Fauna database.  The location `timestamp` is not one of the fields that is stored in the database.  I think it should be fine since Walgreens and CVS were already sending the timestamp to the database.
