### PR TITLE
updated url in Umass Amherst scraper

### DIFF
--- a/site-scrapers/UMassAmherst/config.js
+++ b/site-scrapers/UMassAmherst/config.js
@@ -3,7 +3,7 @@ const site = {
     street: "1 Campus Center Way",
     city: "Amherst",
     zip: "01003",
-    signUpLink: "https://uma.force.com/covidtesting/s/first-responders",
+    signUpLink: "https://uma.force.com/covidtesting/s/vaccination",
     restrictions: "Eligible populations in Western MA",
 };
 


### PR DESCRIPTION
See slack thread: https://macovidvaccines.slack.com/archives/C01NADTMYQM/p1618334537115600

The vax location migrated their website from one url to another. Running this scraper locally, I see the following output at the moment:
```
{
    "version": 1,
    "timestamp": "2021-04-13T175429Z",
    "results": [
        {
            "name": "UMass Amherst Campus Center",
            "street": "1 Campus Center Way",
            "city": "Amherst",
            "zip": "01003",
            "signUpLink": "https://uma.force.com/covidtesting/s/vaccination",
            "restrictions": "Eligible populations in Western MA",
            "hasAvailability": false,
            "timestamp": "2021-04-13T13:54:26-04:00",
            "latitude": 42.3917296,
            "longitude": -72.52702339999999
        }
    ]
}
``` 
which is to be expected.
