### PR TITLE
fix test exclusion, for workflow running on forks

### DIFF
--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -35,7 +35,7 @@ jobs:
           if [ -z "${{ secrets.FAUNA_DB_DEV }}" ] || [ -z "${{ secrets.GOOGLE_API_KEY }}" ]
           then
             echo "\$FAUNA_DB_DEV or \$GOOGLE_API_KEY secret does not exist, skipping Fauna tests"
-            npm test --  --exclude **/db*
+            npm test -- --exclude **/db/utils_test.js --exclude **/db/scraper_test.js
           else
             echo "Necessary secrets exist, running all tests"
             npm test


### PR DESCRIPTION
I made this PR on a fork to test the failure we see on forks: https://github.com/livgust/covid-vaccine-scrapers/runs/2463312999?check_suite_focus=true

Added logic to explicitly exclude the two files we need, when running the workflow on forks (which have no fauna creds). 

Before:
running `npm test -- --exclude **/db*` locally runs 10 tests (just the Fauna ones - we wanted to skip these, not run them!)

After:
running `npm test -- --exclude **/db/utils_test.js --exclude **/db/scraper_test.js` shows 78 tests passing, 4 pending.
