### PR TITLE
Skipping scrapers

### DIFF
--- a/scraper_common.js
+++ b/scraper_common.js
@@ -23,7 +23,7 @@ const moment = require("moment");
 const AWS = require("aws-sdk");
 const { Lambda } = require("faunadb");
 const alertsLambda = new AWS.Lambda();
-
+const { scrapersToSkip } = require("./scraper_config");
 const WRITE_TO_FAUNA = true;
 
 async function execute(usePuppeteer, scrapers) {
@@ -56,6 +56,13 @@ async function execute(usePuppeteer, scrapers) {
     const gatherData = async () => {
         const results = [];
         for (const scraper of scrapers) {
+            if (scrapersToSkip.indexOf(scraper.name) !== -1) {
+                console.log(
+                    "Skipping... " + scraper.name + " (see scraper_config.js)"
+                );
+                continue;
+            }
+
             const startTime = new Date();
             let isSuccess = true;
             const returnValue = await scraper.run(browser).catch((error) => {

--- a/scraper_config.js
+++ b/scraper_config.js
@@ -1,0 +1,15 @@
+/* The following scrapers will be skipped */
+const scrapersToSkip = [
+    "Atrius",
+    "Curative",
+    "FamilyPracticeGroup",
+    "LowellGeneral",
+    "PediatricAssociatesOfGreaterSalem",
+    "SouthLawrence",
+    "TrinityEMS",
+    "Wegmans",
+];
+
+module.exports = {
+    scrapersToSkip,
+};


### PR DESCRIPTION
There are a number of scrapers that are either broken or haven't returned results for 3 weeks.  By removing some of these non-functional scrapers it is hoped that we can reduce our resource requirements and increase of chance of successfully scraping the sites that do have availability.

The file `scraper_config.js` has a list of **directories** that should be not be scraped.

```
    "Atrius",
    "Curative",
    "FamilyPracticeGroup",
    "LowellGeneral",
    "PediatricAssociatesOfGreaterSalem",
    "SouthLawrence",
    "TrinityEMS",
    "Wegmans",
```