### PR TITLE
Stop & Shop quick fix

### DIFF
--- a/site-scrapers/StopAndShop/index.js
+++ b/site-scrapers/StopAndShop/index.js
@@ -6,10 +6,11 @@ function TitleCase(str) {
     if (!str) return str;
 
     return str
+        .trim()
         .toLowerCase()
         .split(" ")
         .map(function (word) {
-            return word.replace(word[0], word[0].toUpperCase());
+            return !word ? word : word.replace(word[0], word[0].toUpperCase());
         })
         .join(" ");
 }


### PR DESCRIPTION
The TitleCase() function failed if the string had a leading space. Trimmed and checked now.

Now...
```
 672 MEMORIAL DRIVE, ROUTE 33
672 Memorial Drive, Route 33
```