### PR TITLE
page.close() called on all scrapers

### DIFF
--- a/lib/RxTouch.js
+++ b/lib/RxTouch.js
@@ -180,6 +180,7 @@ async function ScrapeRxTouch(browser, site, siteName, appointmentType) {
             }
         }
     }
+    page.close();
     return results;
 }
 

--- a/scraper_common.js
+++ b/scraper_common.js
@@ -139,6 +139,14 @@ async function execute(usePuppeteer, scrapers) {
             }
         }
         if (usePuppeteer) {
+            const pages = await browser.pages();
+            if (pages.length > 1) {
+                console.log(
+                    "Did you forget to call page.close()? The following pages were left open... " +
+                        pages.map((page) => page.url())
+                );
+            }
+
             await browser.close();
         }
         let scrapedResultsArray = [];

--- a/scraper_config.js
+++ b/scraper_config.js
@@ -5,6 +5,7 @@ const scrapersToSkip = [
     "FamilyPracticeGroup",
     "LowellGeneral",
     "PediatricAssociatesOfGreaterSalem",
+    "ReverePopup",
     "SouthLawrence",
     "TrinityEMS",
     "Wegmans",

--- a/site-scrapers/BaystateHealth/index.js
+++ b/site-scrapers/BaystateHealth/index.js
@@ -41,6 +41,7 @@ async function ScrapeWebsiteData(browser) {
         : false);
     let hasAvailability = !alert;
 
+    page.close();
     return {
         hasAvailability,
     };

--- a/site-scrapers/Harrington/index.js
+++ b/site-scrapers/Harrington/index.js
@@ -137,7 +137,7 @@ async function ScrapeWebsiteData(browser, pageService, site) {
     results.hasAvailability = !!Object.keys(results.availability).length;
 
     console.log(`${site.name} scrape ending`);
-
+    page.close();
     return results;
 }
 

--- a/site-scrapers/MAImmunizations/index.js
+++ b/site-scrapers/MAImmunizations/index.js
@@ -24,11 +24,13 @@ async function ScrapeWebsiteData(browser) {
 
     if ((await page.title()) === "Application Error") {
         console.log("Got the Mass. Heroku error page, giving up.");
+        page.close();
         return {};
     } else if (pages.length < 1) {
         console.log(
             "No content matching our CSS selector (looking for nav.pagination)!"
         );
+        page.close();
         return {};
     } else {
         const maxPage = await pages[pages.length - 1].evaluate(
@@ -156,6 +158,8 @@ async function ScrapeWebsiteData(browser) {
                 }
             }
         }
+        clinicPage.close();
+        page.close();
         return results;
     }
 }

--- a/site-scrapers/MercyMedicalCenter/index.js
+++ b/site-scrapers/MercyMedicalCenter/index.js
@@ -94,6 +94,7 @@ async function ScrapeWebsiteData(browser) {
         }
     }
 
+    page.close();
     return {
         hasAvailability,
         availability,

--- a/site-scrapers/ReverePopup/index.js
+++ b/site-scrapers/ReverePopup/index.js
@@ -48,6 +48,7 @@ async function ScrapeWebsiteData(browser) {
             }, 0)
         );
 
+        page.close();
         if (appointments) {
             results["hasAvailability"] = true;
             results["availability"][date] = {

--- a/site-scrapers/UMassAmherst/index.js
+++ b/site-scrapers/UMassAmherst/index.js
@@ -39,5 +39,6 @@ async function ScrapeWebsiteData(browser) {
             ) == -1,
     };
 
+    page.close();
     return result;
 }

--- a/site-scrapers/Walgreens/index.js
+++ b/site-scrapers/Walgreens/index.js
@@ -114,5 +114,6 @@ async function ScrapeWebsiteData(browser) {
             });
         }
     }
+    page.close();
     return Object.values(availableLocations);
 }


### PR DESCRIPTION
We were unnecessarily leaving pages open when a scraper ended which is wasting resources.

I added a warning message for future developers to remind them to clean up after themselves by calling page.close().