### PR TITLE
Skip Walgreens scraper

### DIFF
--- a/scraper_config.js
+++ b/scraper_config.js
@@ -7,6 +7,7 @@ const scrapersToSkip = [
     "ReverePopup",
     "SouthLawrence",
     "TrinityEMS",
+    "Walgreens",
     "Wegmans",
 ];
 


### PR DESCRIPTION
Walgreens scraper fails on CSRF error. (see Issue #273)
Until the scraper is repaired, let's not waste everyone's resources repeatedly trying it.