### PR TITLE
Shaws / Stop&Shop address formatting

### DIFF
--- a/no-browser-site-scrapers/Albertsons/index.js
+++ b/no-browser-site-scrapers/Albertsons/index.js
@@ -21,15 +21,24 @@ module.exports = async function GetAvailableAppointments() {
         isChain: true,
         timestamp: moment().format(),
         individualLocationData: massLocations.map((location) => {
-            // Raw address is like: (Star Market 4587 - 45 William T Morrissey Blvd, Dorchester, MA, 02125)
+            // Raw address is like: (Star Market 4587 - Pfizer and Moderna Availability||45 William T Morrissey Blvd, Dorchester, MA, 02125)
             // The format seems to be very consistent nationally, not to mention locally in MA. So we
             // pull the specific parts out of the string.
             const rawAddress = location.address;
             const trimmedAddress = rawAddress.replace(/^\(|\)$/, ""); // Trim parens
-            const [name, longAddress] = trimmedAddress.split(" - ");
+            let [name, addressRest] = trimmedAddress.split(" - ");
+            let [vaccine, longAddress] = addressRest.split("||");
+            if (addressRest.indexOf("||") === -1) {
+                longAddress = vaccine;
+                vaccine = undefined;
+            }
             const [street, city, state, zip] = longAddress.split(", ");
             const storeName = name.match(/([^\d]*) /g)[0].trim();
             // const storeNumber = name.substring(storeName.length).trim();
+
+            const extraData = vaccine
+                ? { extraData: { "Vaccinations offered": vaccine } }
+                : undefined;
 
             const retval = {
                 name: storeName,
@@ -38,6 +47,7 @@ module.exports = async function GetAvailableAppointments() {
                 state: state,
                 zip: zip,
                 hasAvailability: location.availability === "yes",
+                ...extraData,
                 signUpLink: location.coach_url,
                 latitude: location.lat,
                 longitude: location.long,

--- a/no-browser-site-scrapers/Albertsons/index.js
+++ b/no-browser-site-scrapers/Albertsons/index.js
@@ -42,8 +42,8 @@ module.exports = async function GetAvailableAppointments() {
 
             const retval = {
                 name: storeName,
-                city: city,
                 street: street,
+                city: city,
                 state: state,
                 zip: zip,
                 hasAvailability: location.availability === "yes",


### PR DESCRIPTION
They changed the return value for locations to be
`Star Market 4587 - Pfizer and Moderna Availability||45 William T Morrissey Blvd, Dorchester, MA, 02125`
it was
`Star Market 4587 - 45 William T Morrissey Blvd, Dorchester, MA, 02125`

Now the vaccine information is shown on its own line, and the address is once again map-able.

**AFTER:** The location card now shows up as:
![image](https://user-images.githubusercontent.com/546007/118708880-46069980-b7ea-11eb-9524-e467e82c08b7.png)

**BEFORE:** The site was showing it as:
![image](https://user-images.githubusercontent.com/546007/118708791-2a9b8e80-b7ea-11eb-9392-399994f27400.png)

